### PR TITLE
Fix LLM node import/runtime issues for external LLM and RAG retriever

### DIFF
--- a/src/llm_pkg/llm_pkg/llm_node.py
+++ b/src/llm_pkg/llm_pkg/llm_node.py
@@ -11,6 +11,7 @@ Publish topics:
 """
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -140,7 +141,11 @@ class VectorRetriever:
             return
         try:
             # Import here so missing deps only fail at search time, not import time
-            from build_index import Retriever
+            try:
+                from .build_index import Retriever
+            except ImportError:
+                # Fallback when run as a standalone script
+                from build_index import Retriever
             self._retriever = Retriever(self.index_dir)
             if self.logger:
                 self.logger.info(f'Vector retriever ready: {self.index_dir}')
@@ -480,7 +485,6 @@ class LLMNode(Node):
 # Entry point
 
 def main(args=None):
-    import os
     rclpy.init(args=args)
     node = LLMNode()
     try:


### PR DESCRIPTION
### Motivation
- External LLM initialization referenced `os` at runtime which could raise `NameError` when `use_external_llm` is enabled.  
- Loading the RAG `Retriever` failed in different execution contexts (package-relative vs standalone script) due to a single import form.  
- The code also contained a redundant local `import os` inside `main()` which was inconsistent with module-level imports.

### Description
- Added `import os` at module scope so `os` is available when initializing external LLM clients (e.g. Gemini API key lookup).  
- Made the vector retriever import robust by preferring `from .build_index import Retriever` and falling back to `from build_index import Retriever` if the relative import fails.  
- Removed the redundant `import os` inside `main()` to keep imports consistent and avoid shadowing.  
- Ensured the changes are minimal and limited to `src/llm_pkg/llm_pkg/llm_node.py`.

### Testing
- Ran `python -m py_compile src/llm_pkg/llm_pkg/llm_node.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b276a63028832cbba7ace498ff119c)