### PR TITLE
Render Connection Info in SystemTab from parsed `wsUrl`

### DIFF
--- a/web/src/core/url.js
+++ b/web/src/core/url.js
@@ -1,0 +1,23 @@
+export function parseWsUrl(rawUrl) {
+  if (typeof rawUrl !== 'string' || rawUrl.trim() === '') return null;
+
+  try {
+    const parsed = new URL(rawUrl.trim());
+    const protocol = parsed.protocol.replace(':', '');
+
+    return {
+      protocol,
+      host: parsed.hostname,
+      port: parsed.port || defaultPortForProtocol(protocol),
+      path: parsed.pathname + parsed.search + parsed.hash,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function defaultPortForProtocol(protocol) {
+  if (protocol === 'ws') return '80';
+  if (protocol === 'wss') return '443';
+  return '-';
+}

--- a/web/src/tabs/SystemTab.jsx
+++ b/web/src/tabs/SystemTab.jsx
@@ -1,13 +1,16 @@
 import Panel from '../components/Panel';
 import { useStore, TOPIC_META } from '../core/store';
+import { parseWsUrl } from '../core/url';
 import './SystemTab.css';
 
 export default function SystemTab() {
   const topicHz  = useStore(s => s.topicHz);
   const connected = useStore(s => s.connected);
   const isDemoMode = useStore(s => s.isDemoMode);
+  const wsUrl = useStore(s => s.wsUrl);
 
   const topics = Object.keys(TOPIC_META);
+  const parsedWsUrl = parseWsUrl(wsUrl);
 
   return (
     <div className="sys-layout">
@@ -40,13 +43,41 @@ export default function SystemTab() {
             </span>
           </div>
           <div className="sys-info-row">
-            <span>Transport</span>
-            <span>rosbridge WebSocket</span>
+            <span>{connected ? 'Current URL' : 'Configured URL'}</span>
+            <span>{wsUrl}</span>
           </div>
-          <div className="sys-info-row">
-            <span>Port</span>
-            <span>9090</span>
-          </div>
+
+          {parsedWsUrl ? (
+            <>
+              <div className="sys-info-row">
+                <span>Transport</span>
+                <span>{parsedWsUrl.protocol.toUpperCase()}</span>
+              </div>
+              <div className="sys-info-row">
+                <span>Host</span>
+                <span>{parsedWsUrl.host}</span>
+              </div>
+              <div className="sys-info-row">
+                <span>Port</span>
+                <span>{parsedWsUrl.port}</span>
+              </div>
+              <div className="sys-info-row">
+                <span>Path</span>
+                <span>{parsedWsUrl.path || '/'}</span>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="sys-info-row">
+                <span>Transport</span>
+                <span style={{ color: 'var(--red)' }}>Invalid URL</span>
+              </div>
+              <div className="sys-info-row">
+                <span>Raw URL</span>
+                <span>{wsUrl || '(empty)'}</span>
+              </div>
+            </>
+          )}
         </div>
       </Panel>
     </div>


### PR DESCRIPTION
### Motivation
- Make the Connection Info panel reflect the actual configured websocket URL instead of hardcoded transport/port values so the UI shows accurate connection details.
- Provide a resilient UI that distinguishes the active connection from the stored configuration and handles malformed URLs gracefully.

### Description
- Added a URL parsing utility `web/src/core/url.js` with `parseWsUrl(rawUrl)` that returns `protocol`, `host`, `port`, and `path` and supplies sane default ports for `ws`/`wss`.
- Updated `web/src/tabs/SystemTab.jsx` to read `wsUrl` via `useStore(s => s.wsUrl)` and call `parseWsUrl` to render `Transport`, `Host`, `Port`, and `Path` instead of hardcoded values.
- Display the raw `wsUrl` under a `Current URL` (when `connected`) or `Configured URL` (when not connected) label.
- Added fallback UI that shows `Invalid URL` (colored) and the raw URL when parsing fails.

### Testing
- `npm run build` was executed and passed successfully.
- `npm run lint` was executed and failed due to pre-existing lint errors in unrelated files `web/src/core/ros.js` and `web/src/panels/EventLog.jsx` (no new lint issues introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c805a0d4832c95ede34a14c2d076)