### PR TITLE
Make Header ROS connect flow async-safe and improve error reporting

### DIFF
--- a/web/src/components/Header.jsx
+++ b/web/src/components/Header.jsx
@@ -13,18 +13,59 @@ export default function Header({ onLogoClick, themeMode, onThemeModeChange }) {
   const addLog       = useStore(s => s.addLog);
 
   const [urlInput, setUrlInput] = useState(wsUrl);
+  const [isConnecting, setIsConnecting] = useState(false);
 
-  function handleConnect() {
+  function formatConnectError(error, url, source = 'network') {
+    const message = String(error?.message || error || 'Unknown error');
+    if (source === 'url') {
+      return `Connection failed [url]: Invalid WebSocket URL (${url}). Use ws:// or wss://.`;
+    }
+    if (source === 'loading' || message.includes('Script error') || message.includes('Failed to fetch')) {
+      return `Connection failed [loading]: Failed to load ROS client library. (${message})`;
+    }
+    return `Connection failed [network]: Could not open WebSocket (${url}). (${message})`;
+  }
+
+  async function handleConnect() {
+    if (isConnecting) return;
+
     if (connected) {
       disconnectROS(); setConnected(false); addLog(LOG_TAGS.SYS, 'Disconnected from ROS');
     } else {
-      stopDemo();
-      connectROS(urlInput, {
-        onConnect: () => { setConnected(true); addLog(LOG_TAGS.SYS, `Connected → ${urlInput}`); },
-        onError:   (e) => addLog(LOG_TAGS.ERROR, `WebSocket error: ${e}`),
-        onClose:   () => { setConnected(false); addLog(LOG_TAGS.SYS, 'Connection closed'); },
-      });
-      setWsUrl(urlInput);
+      try {
+        // quick URL sanity check for clearer user-facing errors
+        const parsed = new URL(urlInput);
+        if (!['ws:', 'wss:'].includes(parsed.protocol)) {
+          throw new Error('URL protocol must be ws:// or wss://');
+        }
+
+        setIsConnecting(true);
+        setConnected(false);
+        stopDemo();
+        await connectROS(urlInput, {
+          onConnect: () => {
+            setConnected(true);
+            setIsConnecting(false);
+            addLog(LOG_TAGS.SYS, `Connected → ${urlInput}`);
+          },
+          onError: (e) => {
+            setConnected(false);
+            setIsConnecting(false);
+            addLog(LOG_TAGS.ERROR, formatConnectError(e, urlInput, 'network'));
+          },
+          onClose: () => {
+            setConnected(false);
+            setIsConnecting(false);
+            addLog(LOG_TAGS.SYS, 'Connection closed');
+          },
+        });
+        setWsUrl(urlInput);
+      } catch (e) {
+        const source = e instanceof TypeError || e.message?.includes('protocol') ? 'url' : 'loading';
+        setConnected(false);
+        setIsConnecting(false);
+        addLog(LOG_TAGS.ERROR, formatConnectError(e, urlInput, source));
+      }
     }
   }
 
@@ -63,11 +104,15 @@ export default function Header({ onLogoClick, themeMode, onThemeModeChange }) {
           value={urlInput}
           onChange={e => setUrlInput(e.target.value)}
           onKeyDown={e => e.key === 'Enter' && handleConnect()}
-          disabled={connected || isDemoMode}
+          disabled={connected || isDemoMode || isConnecting}
           spellCheck={false}
         />
-        <button className={`hdr-btn ${connected ? 'connected' : ''}`} onClick={handleConnect}>
-          {connected ? '⏏ disconnect' : '⏎ connect'}
+        <button
+          className={`hdr-btn ${connected ? 'connected' : ''}`}
+          onClick={handleConnect}
+          disabled={isDemoMode || isConnecting}
+        >
+          {isConnecting ? 'connecting...' : (connected ? '⏏ disconnect' : '⏎ connect')}
         </button>
         <button className={`hdr-btn demo ${isDemoMode ? 'active' : ''}`} onClick={handleDemo}>
           {isDemoMode ? '■ stop demo' : '▶ demo'}


### PR DESCRIPTION
### Motivation
- Make the ROS WebSocket connect flow in the header robust against async failures and duplicate clicks. 
- Provide clearer, actionable error messages distinguishing URL, loading, and network failures. 
- Restore UI state reliably on failure so the user can retry connections.

### Description
- Converted `handleConnect` to `async` and used `await connectROS(...)` to ensure the connection lifecycle is awaited. 
- Added `isConnecting` local state to prevent duplicate connection attempts and to drive UI disabling while connecting. 
- Wrapped the connect flow in a `try/catch`, added URL sanity-checking for `ws://`/`wss://`, and restored `connected`/`isConnecting` state on errors. 
- Introduced `formatConnectError` to classify and log errors as `url`, `loading`, or `network`, and updated the connect button label to `connecting...` and disabled the URL input/button during attempts.

### Testing
- Ran `cd web && npm run build` which completed successfully. 
- Ran `cd web && npm run lint` which failed due to unrelated pre-existing lint errors in `web/src/core/ros.js` and `web/src/panels/EventLog.jsx` (these lint issues were present before this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cae3c8dc832cb1c4cdd5df57677d)