### PR TITLE
Align dashboard_pkg entrypoint, web asset packaging, and launch validation

### DIFF
--- a/src/dashboard_pkg/dashboard_pkg/dori_bridge.py
+++ b/src/dashboard_pkg/dashboard_pkg/dori_bridge.py
@@ -1,0 +1,14 @@
+"""Entry point for the dashboard bridge process."""
+
+
+def main() -> None:
+    """Start the dashboard bridge.
+
+    The bridge logic is not implemented yet, but this entry point is kept so the
+    installed console script resolves to a valid module/function pair.
+    """
+    print('dashboard_pkg.dori_bridge is available, but bridge logic is not implemented yet.')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dashboard_pkg/launch/dashboard.launch.py
+++ b/src/dashboard_pkg/launch/dashboard.launch.py
@@ -1,13 +1,20 @@
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.actions import ExecuteProcess
+from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
+
 
 def generate_launch_description():
     pkg_dir = get_package_share_directory('dashboard_pkg')
     web_dir = os.path.join(pkg_dir, 'web')
-    
+
+    if not os.path.isdir(web_dir):
+        raise FileNotFoundError(
+            'dashboard_pkg web assets not found. Expected directory: '
+            f"'{web_dir}'. Build the frontend (web/dist) before installing and launching dashboard_pkg."
+        )
+
     return LaunchDescription([
         # rosbridge WebSocket server node
         Node(
@@ -18,7 +25,7 @@ def generate_launch_description():
                 'port': 9090,
             }]
         ),
-        
+
         # React web serving by simple HTTP server
         ExecuteProcess(
             cmd=['python3', '-m', 'http.server', '3000'],

--- a/src/dashboard_pkg/setup.py
+++ b/src/dashboard_pkg/setup.py
@@ -1,8 +1,27 @@
+from pathlib import Path
 from setuptools import find_packages, setup
 from glob import glob
 import os
 
 package_name = 'dashboard_pkg'
+setup_dir = Path(__file__).resolve().parent
+repo_root = setup_dir.parents[1]
+
+
+def collect_web_data_files():
+    """Collect web build artifacts from the repository-level web/dist directory."""
+    web_dist_dir = repo_root / 'web' / 'dist'
+    if not web_dist_dir.exists():
+        return []
+
+    collected = []
+    for src_path in sorted(p for p in web_dist_dir.rglob('*') if p.is_file()):
+        relative_parent = src_path.parent.relative_to(web_dist_dir)
+        install_dir = Path('share') / package_name / 'web' / relative_parent
+        collected.append((str(install_dir), [str(src_path)]))
+
+    return collected
+
 
 setup(
     name=package_name,
@@ -13,8 +32,7 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
-        (os.path.join('share', package_name, 'web'), glob('web/dist/**/*', recursive=True)),
-    ],
+    ] + collect_web_data_files(),
     install_requires=['setuptools'],
     zip_safe=True,
     maintainer='ofbt',


### PR DESCRIPTION
### Motivation
- Ensure the package entrypoint referenced by `console_scripts` actually exists and resolves at runtime so installs don't fail with import errors. 
- Make the `setup.py` packaging of web assets match the repository layout (`web/dist`) instead of relying on a non-existent package-internal `web/dist` path. 
- Fail early with a clear error from the launch file when the installed web assets are missing so launch-time troubleshooting is easier.

### Description
- Added `src/dashboard_pkg/dashboard_pkg/dori_bridge.py` with a minimal but valid `main()` entrypoint so the existing `console_scripts` entry `dori_bridge = dashboard_pkg.dori_bridge:main` resolves. 
- Reworked `src/dashboard_pkg/setup.py` to add `collect_web_data_files()` which gathers files from the repository `web/dist` directory and maps them into `share/dashboard_pkg/web/...` for installation. 
- Removed the broken `glob('web/dist/**/*', recursive=True)` data_files entry and replaced it with the dynamic collector so packaging reflects the repo build output when present. 
- Updated `src/dashboard_pkg/launch/dashboard.launch.py` to verify `web_dir` exists and raise a `FileNotFoundError` with an explanatory message if the web assets are missing.

### Testing
- Ran `python3 -m compileall src/dashboard_pkg` and byte-compilation completed successfully. 
- No unit tests were added or run as part of this change; packaging/launch behaviors rely on presence of `web/dist` at build/install time which can be validated during CI or package install steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d5a62d54832c83a47a7f4528b81b)