### PR TITLE
Bundle roslib import and improve connection error diagnostics

### DIFF
--- a/web/src/components/Header.jsx
+++ b/web/src/components/Header.jsx
@@ -17,13 +17,26 @@ export default function Header({ onLogoClick, themeMode, onThemeModeChange }) {
 
   function formatConnectError(error, url, source = 'network') {
     const message = String(error?.message || error || 'Unknown error');
+    const eventType = error?.type;
+    const target = error?.target;
+    const readyState = target?.readyState;
+    const stateLabel = readyState === undefined
+      ? 'n/a'
+      : ['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'][readyState] || String(readyState);
+    const debugParts = [
+      `url=${url || 'n/a'}`,
+      `eventType=${eventType || 'n/a'}`,
+      `readyState=${stateLabel}`,
+      `message=${message}`,
+    ];
+
     if (source === 'url') {
-      return `Connection failed [url]: Invalid WebSocket URL (${url}). Use ws:// or wss://.`;
+      return `Connection failed [url]: Invalid WebSocket URL. ${debugParts.join(', ')}. Use ws:// or wss://.`;
     }
-    if (source === 'loading' || message.includes('Script error') || message.includes('Failed to fetch')) {
-      return `Connection failed [loading]: Failed to load ROS client library. (${message})`;
+    if (source === 'loading' || message.includes('ROSLIB is unavailable') || message.includes('Failed to fetch')) {
+      return `Connection failed [loading]: Failed to load ROS client library. ${debugParts.join(', ')}`;
     }
-    return `Connection failed [network]: Could not open WebSocket (${url}). (${message})`;
+    return `Connection failed [network]: Could not open WebSocket. ${debugParts.join(', ')}`;
   }
 
   async function handleConnect() {

--- a/web/src/core/ros.js
+++ b/web/src/core/ros.js
@@ -1,38 +1,29 @@
 /**
  * core/ros.js
  * ROS WebSocket singleton.
- * Dynamically loads roslibjs from CDN so no npm package needed.
+ * Uses bundled roslib package first, with optional global fallback.
  * Usage:
  *   import { connectROS, disconnectROS, subscribeROS, publishROS } from './core/ros'
  */
 
-const ROSLIB_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/roslibjs/1.3.0/roslib.min.js';
+import * as ROSLIB from 'roslib';
 
 let ros = null;
-let loadPromise = null;
 const subscribers = {}; // topic -> ROSLIB.Topic
 const listeners = {};   // topic -> Set<callback>
 
-// ─── Load roslibjs ─────────────────────────────────────────────────────────
-function loadROSLib() {
-  if (loadPromise) return loadPromise;
-  if (window.ROSLIB) { loadPromise = Promise.resolve(); return loadPromise; }
-  loadPromise = new Promise((resolve, reject) => {
-    const s = document.createElement('script');
-    s.src = ROSLIB_CDN;
-    s.onload = resolve;
-    s.onerror = reject;
-    document.head.appendChild(s);
-  });
-  return loadPromise;
+function getROSLib() {
+  if (ROSLIB) return ROSLIB;
+  if (typeof window !== 'undefined' && window.ROSLIB) return window.ROSLIB;
+  throw new Error('ROSLIB is unavailable. Check local bundle/dependency loading state.');
 }
 
 // ─── Connect ────────────────────────────────────────────────────────────────
 export async function connectROS(url, { onConnect, onError, onClose } = {}) {
-  await loadROSLib();
+  const roslib = getROSLib();
   if (ros) { ros.close(); ros = null; }
 
-  ros = new window.ROSLIB.Ros({ url });
+  ros = new roslib.Ros({ url });
 
   ros.on('connection', () => {
     onConnect?.();
@@ -42,7 +33,7 @@ export async function connectROS(url, { onConnect, onError, onClose } = {}) {
   ros.on('error',   e => onError?.(e));
   ros.on('close',   () => {
     onClose?.();
-    Object.values(subscribers).forEach(s => { try { s.unsubscribe(); } catch (_) {} });
+    Object.values(subscribers).forEach(s => { try { s.unsubscribe(); } catch { return; } });
     Object.keys(subscribers).forEach(k => delete subscribers[k]);
   });
 }
@@ -82,9 +73,10 @@ export function subscribeROS(topic, msgType, cb) {
 }
 
 function _subscribe(topic, msgType) {
-  if (!ros || !window.ROSLIB) return;
+  if (!ros) return;
+  const roslib = getROSLib();
   const type = msgType || _inferMsgType(topic);
-  const sub = new window.ROSLIB.Topic({ ros, name: topic, messageType: type });
+  const sub = new roslib.Topic({ ros, name: topic, messageType: type });
   sub.subscribe(msg => {
     const val = msg.data !== undefined ? msg.data : msg;
     listeners[topic]?.forEach(cb => cb(val));
@@ -103,7 +95,8 @@ function _inferMsgType(topic) {
 
 // ─── Publish ─────────────────────────────────────────────────────────────────
 export function publishROS(topic, msgType, data) {
-  if (!ros || !window.ROSLIB) return;
-  const t = new window.ROSLIB.Topic({ ros, name: topic, messageType: msgType });
-  t.publish(new window.ROSLIB.Message(data));
+  if (!ros) return;
+  const roslib = getROSLib();
+  const t = new roslib.Topic({ ros, name: topic, messageType: msgType });
+  t.publish(new roslib.Message(data));
 }


### PR DESCRIPTION
### Motivation
- 번들 외부의 CDN `<script>` 주입 방식은 취약하고 번들링/배포에서 예측하기 어려워 `roslib`를 로컬 번들 우선으로 포함하도록 변경했습니다.
- 전역 `window.ROSLIB` 참조를 직접 import 기반 호출로 바꿔 번들러 친화적이고 명확한 생성자 사용을 보장합니다.
- 연결 실패 시 `[object Event]`처럼 디버깅이 어려운 메시지 대신 `url`, `eventType`, `readyState`, `message` 등 유의미한 정보를 남기도록 개선합니다.

### Description
- `web/src/core/ros.js`에서 CDN 로드(`ROSLIB_CDN` 및 `loadROSLib()` 함수) 관련 로직을 제거하고 `import * as ROSLIB from 'roslib';`를 추가해 번들 우선 사용으로 전환했습니다.
- `getROSLib()` 가드를 도입해 번들 import가 없을 경우에만 `window.ROSLIB`를 폴백으로 사용하고, 둘 다 없으면 명확한 에러(`ROSLIB is unavailable...`)를 던지도록 했습니다.
- 코드 전반에서 `new window.ROSLIB.Ros/Topic/Message` 사용을 `new roslib.Ros/Topic/Message`(import 식별자 기반)로 교체하고, 구독/발행 로직에서 적절히 `roslib`를 참조하도록 수정했습니다.
- `web/src/components/Header.jsx`의 `formatConnectError`를 보강해 `url`, `eventType`, `readyState`, `message`를 포함한 디버깅 가능한 사용자 메시지를 생성하도록 변경했습니다.

### Testing
- 실행: `npm run build` (작업 디렉터리: `web`) — 빌드 성공으로 번들에 `roslib`가 포함되는 것을 확인했습니다.
- 실행: `npm run lint` (작업 디렉터리: `web`) — 린트는 `web/src/panels/EventLog.jsx`의 기존 오류로 실패했으며, 이번 PR로 변경된 파일(`web/src/core/ros.js`, `web/src/components/Header.jsx`)에서는 새로운 린트 오류가 발생하지 않았습니다.
- 수동검증: 빌드 후 에러 포맷이 `Header.jsx`에서 디버깅 필드를 포함하도록 변경된 것을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3005c445c832ca5e0976b6cad3f46)