### PR TITLE
docs: update dashboard launch flow and frontend prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,14 +314,40 @@ Korean TTS with `gtts` (online) or `pyttsx3` (offline). Publishes `/dori/tts/spe
 A browser-based debug dashboard is available, serving both an HRI monitor and a 3×3 cube simulator.
 
 ```bash
-# Start rosbridge + HTTP server
-ros2 launch cubesim_pkg cubesim.launch.py
+# 1) Build the frontend assets first (required)
+cd web
+npm ci   # or: npm install
+npm run build
 
-# Access from any device on the same network
-http://[Robot IP]:3000
+# 2) Return to ROS workspace root
+cd ..
+
+# 3) Build workspace and source overlay
+colcon build --symlink-install
+source install/setup.bash
+
+# 4) Start dashboard backend (rosbridge + HTTP server)
+ros2 launch dashboard_pkg dashboard.launch.py
 ```
 
-The dashboard connects to ROS2 via WebSocket (`ws://[Robot IP]:9090`) and displays real-time topic values, HRI state, person tracking, gesture/expression state, and event log.
+Dashboard access endpoints:
+
+- Dashboard URL: `http://[Robot IP]:3000`
+- ROS WebSocket URL: `ws://[Robot IP]:9090`
+
+Connection examples:
+
+```text
+# Local access on robot host
+http://localhost:3000
+ws://localhost:9090
+
+# Remote access from another device on the same network
+http://[Robot IP]:3000
+ws://[Robot IP]:9090
+```
+
+The dashboard displays real-time topic values, HRI state, person tracking, gesture/expression state, and event log through the ROS WebSocket bridge.
 
 ---
 

--- a/web/README.md
+++ b/web/README.md
@@ -1,16 +1,41 @@
-# React + Vite
+# DORI Dashboard Frontend (`web`)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This directory contains the Vite/React frontend for the DORI dashboard.
 
-Currently, two official plugins are available:
+## Build (Required before ROS launch)
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Build frontend assets before launching `dashboard_pkg` from the ROS workspace root.
 
-## React Compiler
+```bash
+cd web
+npm ci   # or: npm install
+npm run build
+```
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+After the build completes, continue from the ROS workspace root:
 
-## Expanding the ESLint configuration
+```bash
+cd ..
+colcon build --symlink-install
+source install/setup.bash
+ros2 launch dashboard_pkg dashboard.launch.py
+```
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+## Access
+
+- Dashboard: `http://[Robot IP]:3000`
+- ROS WebSocket bridge: `ws://[Robot IP]:9090`
+
+Examples:
+
+```text
+# Same machine (robot/local)
+http://localhost:3000
+ws://localhost:9090
+
+# Another device on same network (remote)
+http://[Robot IP]:3000
+ws://[Robot IP]:9090
+```
+
+For broader project context, see the root README: `../README.md`.


### PR DESCRIPTION
### Motivation

- Replace an outdated dashboard run instruction that referenced `cubesim_pkg` with the correct `dashboard_pkg` launch flow.
- Make the frontend build a documented prerequisite so the dashboard static assets are available before launching the ROS backend.
- Clarify access endpoints and provide local/remote connection examples for easier testing and debugging.

### Description

- Updated the root `README.md` Dashboard section to document the sequence: build frontend (`cd web && npm ci || npm install && npm run build`), return to workspace root, run `colcon build --symlink-install` and `source install/setup.bash`, then launch `ros2 launch dashboard_pkg dashboard.launch.py`.
- Added explicit Dashboard endpoint and ROS WebSocket bridge lines: `http://[Robot IP]:3000` and `ws://[Robot IP]:9090` with local (`localhost`) and remote (`[Robot IP]`) examples.
- Rewrote `web/README.md` to replace the Vite template text with a project-specific DORI dashboard frontend guide that reiterates build steps, launch sequence, access URLs, and links back to the root `README.md`.
- This change is documentation-only and does not modify runtime code or node logic.

### Testing

- Verified the updated files contain `dashboard_pkg`, frontend build steps, and endpoint strings using `rg` searches which returned the expected matches.
- Inspected the updated Dashboard section and `web/README.md` excerpts with `nl`/`sed` to confirm the new command sequence and examples appear in the expected location.
- No automated unit tests were applicable because this is a docs-only change and validation was limited to automated text inspections which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b301ed3390832cb80a3bf15eeebd22)