### PR TITLE
feat(web): implement functional Cube tab panels and controls

### DIFF
--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -11,6 +11,84 @@
 
 import { create } from 'zustand';
 
+const FACE_KEYS = ['U', 'R', 'F', 'D', 'L', 'B'];
+const FACE_COLORS = Object.freeze({
+  U: 'W',
+  R: 'R',
+  F: 'G',
+  D: 'Y',
+  L: 'O',
+  B: 'B',
+});
+
+const rotateFaceCW = (face) => ([
+  face[6], face[3], face[0],
+  face[7], face[4], face[1],
+  face[8], face[5], face[2],
+]);
+
+const createSolvedCube = () => Object.fromEntries(
+  FACE_KEYS.map((k) => [k, new Array(9).fill(FACE_COLORS[k])]),
+);
+
+const applyMove = (cube, move) => {
+  const next = Object.fromEntries(FACE_KEYS.map((k) => [k, [...cube[k]]]));
+
+  const turn = () => {
+    switch (move) {
+      case 'U': {
+        next.U = rotateFaceCW(next.U);
+        const temp = [cube.F[0], cube.F[1], cube.F[2]];
+        [next.F[0], next.F[1], next.F[2]] = [cube.L[0], cube.L[1], cube.L[2]];
+        [next.L[0], next.L[1], next.L[2]] = [cube.B[0], cube.B[1], cube.B[2]];
+        [next.B[0], next.B[1], next.B[2]] = [cube.R[0], cube.R[1], cube.R[2]];
+        [next.R[0], next.R[1], next.R[2]] = temp;
+        break;
+      }
+      case 'R': {
+        next.R = rotateFaceCW(next.R);
+        const temp = [cube.U[2], cube.U[5], cube.U[8]];
+        [next.U[2], next.U[5], next.U[8]] = [cube.F[2], cube.F[5], cube.F[8]];
+        [next.F[2], next.F[5], next.F[8]] = [cube.D[2], cube.D[5], cube.D[8]];
+        [next.D[2], next.D[5], next.D[8]] = [cube.B[6], cube.B[3], cube.B[0]];
+        [next.B[6], next.B[3], next.B[0]] = temp;
+        break;
+      }
+      case 'L': {
+        next.L = rotateFaceCW(next.L);
+        const temp = [cube.U[0], cube.U[3], cube.U[6]];
+        [next.U[0], next.U[3], next.U[6]] = [cube.B[8], cube.B[5], cube.B[2]];
+        [next.B[8], next.B[5], next.B[2]] = [cube.D[6], cube.D[3], cube.D[0]];
+        [next.D[6], next.D[3], next.D[0]] = [cube.F[0], cube.F[3], cube.F[6]];
+        [next.F[0], next.F[3], next.F[6]] = temp;
+        break;
+      }
+      case 'B': {
+        next.B = rotateFaceCW(next.B);
+        const temp = [cube.U[0], cube.U[1], cube.U[2]];
+        [next.U[0], next.U[1], next.U[2]] = [cube.R[2], cube.R[5], cube.R[8]];
+        [next.R[2], next.R[5], next.R[8]] = [cube.D[8], cube.D[7], cube.D[6]];
+        [next.D[8], next.D[7], next.D[6]] = [cube.L[6], cube.L[3], cube.L[0]];
+        [next.L[6], next.L[3], next.L[0]] = temp;
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  if (move.endsWith("'")) {
+    const base = move[0];
+    for (let i = 0; i < 3; i += 1) {
+      Object.assign(next, applyMove(next, base));
+    }
+    return next;
+  }
+
+  turn();
+  return next;
+};
+
 // ─── Constants ──────────────────────────────────────────────────────────────
 export const HRI_STATES = ['IDLE', 'LISTENING', 'RESPONDING', 'NAVIGATING'];
 
@@ -78,6 +156,21 @@ export const useStore = create((set, get) => ({
   setConnected: (v) => set({ connected: v }),
   setDemoMode:  (v) => set({ isDemoMode: v }),
   setWsUrl:     (v) => set({ wsUrl: v }),
+
+  // ── Cube Sim ────────────────────────────────────────────────────────────
+  cubeState: createSolvedCube(),
+  cubeMoveHistory: [],
+  resetCube: () => set({ cubeState: createSolvedCube(), cubeMoveHistory: [] }),
+  rotateCube: (move) => set((s) => {
+    const normalized = (move || '').trim().toUpperCase();
+    if (!['U', "U'", 'R', "R'", 'L', "L'", 'B', "B'"].includes(normalized)) {
+      return s;
+    }
+    return {
+      cubeState: applyMove(s.cubeState, normalized),
+      cubeMoveHistory: [...s.cubeMoveHistory, normalized].slice(-100),
+    };
+  }),
 
   // ── HRI State Machine ───────────────────────────────────────────────────
   hriState: 'IDLE',

--- a/web/src/tabs/CubeTab.css
+++ b/web/src/tabs/CubeTab.css
@@ -1,29 +1,174 @@
 .cube-layout {
   display: grid;
-  grid-template-columns: 1fr 260px;
+  grid-template-columns: 1fr 300px;
   gap: 8px;
   height: 100%;
   padding: 8px;
   overflow: hidden;
 }
-.cube-viewer { height: 100%; }
+
+.cube-viewer {
+  height: 100%;
+}
+
 .cube-side {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-height: 0;
 }
-.cube-side-panel { flex: 1; }
-.cube-placeholder {
+
+.cube-side-panel {
+  flex: 1;
+  min-height: 0;
+}
+
+.cube-viewer-panel {
+  height: 100%;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: 8px;
+}
+
+.cube-viewport {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: radial-gradient(circle at 50% 20%, #2f3d52, #11161e 72%);
+  display: grid;
+  place-items: center;
+  perspective: 1000px;
+  overflow: hidden;
+  touch-action: none;
+  cursor: grab;
+}
+
+.cube-viewport:active {
+  cursor: grabbing;
+}
+
+.cube-3d {
+  position: relative;
+  width: 146px;
+  height: 146px;
+  transform-style: preserve-3d;
+  transition: transform 80ms linear;
+}
+
+.cube-face {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 3px;
+  padding: 4px;
+  background: rgba(8, 11, 17, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 6px;
+  backface-visibility: hidden;
+}
+
+.cube-face-U { transform: rotateX(90deg) translateZ(73px); }
+.cube-face-D { transform: rotateX(-90deg) translateZ(73px); }
+.cube-face-F { transform: translateZ(73px); }
+.cube-face-B { transform: rotateY(180deg) translateZ(73px); }
+.cube-face-R { transform: rotateY(90deg) translateZ(73px); }
+.cube-face-L { transform: rotateY(-90deg) translateZ(73px); }
+
+.cube-sticker {
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.sticker-white { background: #f2f4f8; }
+.sticker-yellow { background: #ecd85b; }
+.sticker-green { background: #53c87a; }
+.sticker-blue { background: #55a7ea; }
+.sticker-red { background: #d66b66; }
+.sticker-orange { background: #d98a52; }
+
+.cube-viewer-help {
+  text-align: center;
+  color: var(--text-2);
+  font-size: 11px;
+}
+
+.piece-state-panel {
+  height: 100%;
+  overflow: auto;
+}
+
+.piece-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.piece-table th,
+.piece-table td {
+  border-bottom: 1px solid var(--line);
+  padding: 4px 6px;
+  text-align: left;
+}
+
+.piece-chip {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+  margin-right: 6px;
+  vertical-align: middle;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.rotation-control-panel {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
   gap: 8px;
   height: 100%;
+}
+
+.rotation-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.rotation-button,
+.rotation-reset {
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--text-1);
+  border-radius: 6px;
+  font-size: 11px;
+  padding: 8px 0;
+  cursor: pointer;
+}
+
+.rotation-button:hover,
+.rotation-reset:hover {
+  filter: brightness(1.1);
+}
+
+.rotation-history {
+  margin-top: auto;
+  min-height: 30px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 6px;
+  color: var(--text-2);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cube-pathfinder-placeholder {
+  height: 100%;
+  display: grid;
+  place-items: center;
   color: var(--text-2);
   font-size: 12px;
 }
-
 
 @media (max-width: 900px) {
   .cube-layout {
@@ -33,14 +178,10 @@
   }
 
   .cube-viewer {
-    min-height: 280px;
-  }
-
-  .cube-side {
-    min-height: 0;
+    min-height: 320px;
   }
 
   .cube-side-panel {
-    min-height: 160px;
+    min-height: 180px;
   }
 }

--- a/web/src/tabs/CubeTab.jsx
+++ b/web/src/tabs/CubeTab.jsx
@@ -1,25 +1,145 @@
+import { useMemo, useState } from 'react';
 import Panel from '../components/Panel';
+import { useStore } from '../core/store';
 import './CubeTab.css';
+
+const FACE_ORDER = ['U', 'R', 'F', 'D', 'L', 'B'];
+const MOVE_BUTTONS = ['U', "U'", 'R', "R'", 'L', "L'", 'B', "B'"];
+const STICKER_CLASS = {
+  W: 'sticker-white',
+  Y: 'sticker-yellow',
+  G: 'sticker-green',
+  B: 'sticker-blue',
+  R: 'sticker-red',
+  O: 'sticker-orange',
+};
+
+function CubeViewerPanel() {
+  const cubeState = useStore((s) => s.cubeState);
+  const [orbit, setOrbit] = useState({ x: -24, y: -32 });
+  const [drag, setDrag] = useState(null);
+
+  const transform = `rotateX(${orbit.x}deg) rotateY(${orbit.y}deg)`;
+
+  const onPointerDown = (e) => {
+    setDrag({ x: e.clientX, y: e.clientY, ox: orbit.x, oy: orbit.y });
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e) => {
+    if (!drag) return;
+    const dx = e.clientX - drag.x;
+    const dy = e.clientY - drag.y;
+    setOrbit({
+      x: Math.max(-75, Math.min(75, drag.ox - dy * 0.35)),
+      y: drag.oy + dx * 0.45,
+    });
+  };
+
+  const onPointerUp = () => setDrag(null);
+
+  return (
+    <div className="cube-viewer-panel">
+      <div
+        className="cube-viewport"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerLeave={onPointerUp}
+        role="presentation"
+      >
+        <div className="cube-3d" style={{ transform }}>
+          {FACE_ORDER.map((face) => (
+            <div key={face} className={`cube-face cube-face-${face}`}>
+              {cubeState[face].map((sticker, i) => (
+                <span
+                  key={`${face}-${i}`}
+                  className={`cube-sticker ${STICKER_CLASS[sticker] || ''}`}
+                  title={`${face}${i + 1}: ${sticker}`}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="cube-viewer-help">드래그해서 카메라 orbit</div>
+    </div>
+  );
+}
+
+function PieceStatePanel() {
+  const cubeState = useStore((s) => s.cubeState);
+  const rows = useMemo(
+    () => FACE_ORDER.flatMap((face) =>
+      cubeState[face].map((color, idx) => ({ face, index: idx + 1, color })),
+    ),
+    [cubeState],
+  );
+
+  return (
+    <div className="piece-state-panel">
+      <table className="piece-table">
+        <thead>
+          <tr>
+            <th>Face</th>
+            <th>Idx</th>
+            <th>Color</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={`${row.face}-${row.index}`}>
+              <td>{row.face}</td>
+              <td>{row.index}</td>
+              <td>
+                <span className={`piece-chip ${STICKER_CLASS[row.color] || ''}`} />
+                {row.color}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RotationControlPanel() {
+  const rotateCube = useStore((s) => s.rotateCube);
+  const resetCube = useStore((s) => s.resetCube);
+  const cubeMoveHistory = useStore((s) => s.cubeMoveHistory);
+
+  return (
+    <div className="rotation-control-panel">
+      <div className="rotation-grid">
+        {MOVE_BUTTONS.map((move) => (
+          <button key={move} className="rotation-button" type="button" onClick={() => rotateCube(move)}>
+            {move}
+          </button>
+        ))}
+      </div>
+      <button className="rotation-reset" type="button" onClick={resetCube}>Reset</button>
+      <div className="rotation-history" title={cubeMoveHistory.join(' ')}>
+        {cubeMoveHistory.length ? cubeMoveHistory.join(' ') : 'No moves yet'}
+      </div>
+    </div>
+  );
+}
 
 export default function CubeTab() {
   return (
     <div className="cube-layout">
       <Panel title="3D Cube Viewer" className="cube-viewer">
-        <div className="cube-placeholder">
-          <span style={{ fontSize: 48, opacity: 0.2 }}>⬛</span>
-          <span>Cube Simulator</span>
-          <span style={{ fontSize: 10, color: 'var(--text-2)' }}>Three.js viewer — coming next</span>
-        </div>
+        <CubeViewerPanel />
       </Panel>
       <div className="cube-side">
         <Panel title="Piece State" className="cube-side-panel">
-          <div className="cube-placeholder" style={{ fontSize: 11 }}>Piece table</div>
+          <PieceStatePanel />
         </Panel>
         <Panel title="Rotation Control" className="cube-side-panel">
-          <div className="cube-placeholder" style={{ fontSize: 11 }}>U / R / L / B buttons</div>
+          <RotationControlPanel />
         </Panel>
         <Panel title="Path Finder" className="cube-side-panel">
-          <div className="cube-placeholder" style={{ fontSize: 11 }}>A→B wheel algorithm</div>
+          <div className="cube-pathfinder-placeholder">미구현 (예정)</div>
         </Panel>
       </div>
     </div>


### PR DESCRIPTION
### Motivation

- Replace the static placeholders in `CubeTab` with real, focused panels to start interactive cube simulation and visualization. 
- Provide minimal but usable 3D viewer and controls so users can orbit the camera and apply basic face turns that update application state. 
- Keep advanced logic (Path Finder / solver) out of scope and leave a clear placeholder for future work while improving CSS structure for maintainability.

### Description

- Split `CubeTab` into three functional components `CubeViewerPanel`, `PieceStatePanel`, and `RotationControlPanel` in `web/src/tabs/CubeTab.jsx`, and replaced placeholders with these components. 
- Added cube simulation state and actions to the Zustand store in `web/src/core/store.js`, including `createSolvedCube`, `applyMove`, `rotateCube`, `resetCube`, and `cubeMoveHistory` to handle `U`, `R`, `L`, `B` moves and prime variants. 
- Implemented a minimal CSS 3D viewer and panel-scoped styles in `web/src/tabs/CubeTab.css` to render six faces (3x3 stickers) and a pointer-drag orbit camera, plus a piece-state table and rotation UI wired to store actions. 
- Left Path Finder unimplemented and present as an explicit placeholder component, as requested.

### Testing

- Ran `npm --prefix web run build` and the production build completed successfully. 
- Ran `npm --prefix web run lint` which failed due to pre-existing lint errors in `web/src/panels/EventLog.jsx` that are unrelated to these changes. 
- Started the dev server and executed an automated Playwright check which loaded the UI and produced a screenshot verifying the new Cube tab renders and responds to the basic interactions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39edb9c04832c89e75f613a7aadcf)