### PR TITLE
Improve Cube Viewer axis behavior and viewport UI

### DIFF
--- a/web/src/tabs/CubeTab.css
+++ b/web/src/tabs/CubeTab.css
@@ -22,9 +22,12 @@
 /* Viewport */
 .cube-viewport {
   position: relative;            /* anchor for overlay controls */
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
   border-radius: var(--radius-lg);
-  background: radial-gradient(circle at 50% 20%, #2f3d52, #11161e 72%);
+  background:
+    radial-gradient(circle at 50% 20%, #324563 0%, #131b27 64%, #0e141d 100%),
+    linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0));
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.06), 0 12px 24px rgba(0,0,0,0.28);
   display: grid;
   place-items: center;
   perspective: 1000px;
@@ -87,23 +90,32 @@
 /* Top-right: icon toggles */
 .vp-controls-tr {
   position: absolute;
-  top: 8px; right: 8px;
-  display: flex; flex-direction: row; gap: 4px;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
   z-index: 10;
 }
 
 .vp-icon-btn {
-  width: 26px; height: 26px;
-  display: flex; align-items: center; justify-content: center;
-  background: rgba(13,17,23,0.72);
+  min-width: 42px;
+  height: 26px;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(9,12,19,0.72);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-radius: 999px;
   color: var(--text-2);
-  font-size: 13px;
-  backdrop-filter: blur(4px);
-  transition: border-color 0.12s, color 0.12s, background 0.12s;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  backdrop-filter: blur(6px);
+  transition: border-color 0.12s, color 0.12s, background 0.12s, transform 0.12s;
 }
-.vp-icon-btn:hover { border-color: var(--border-bright); color: var(--text-0); }
+.vp-icon-btn:hover { border-color: var(--border-bright); color: var(--text-0); transform: translateY(-1px); }
 .vp-icon-btn.active {
   border-color: var(--accent);
   color: var(--accent);
@@ -112,30 +124,38 @@
 
 .vp-icon-text { line-height: 1; }
 
+
 /* Bottom-left: axis indicator */
 .vp-axis-indicator {
   position: absolute;
-  bottom: 8px; left: 8px;
+  bottom: 10px;
+  left: 10px;
   z-index: 10;
-  background: rgba(13,17,23,0.60);
+  background: rgba(13,17,23,0.66);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 2px;
-  backdrop-filter: blur(4px);
+  border-radius: calc(var(--radius) + 2px);
+  padding: 4px;
+  box-shadow: 0 6px 14px rgba(0,0,0,0.24);
+  backdrop-filter: blur(6px);
 }
 .axis-svg { display: block; }
 
 /* Bottom-right: zoom controls (vertical bar) */
 .vp-zoom-controls {
   position: absolute;
-  bottom: 8px; right: 8px;
-  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  bottom: 10px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
   z-index: 10;
-  background: rgba(13,17,23,0.72);
+  background: rgba(13,17,23,0.74);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 6px 4px;
-  backdrop-filter: blur(4px);
+  border-radius: calc(var(--radius) + 2px);
+  padding: 7px 6px;
+  box-shadow: 0 6px 14px rgba(0,0,0,0.24);
+  backdrop-filter: blur(6px);
 }
 
 .vp-zoom-btn {
@@ -151,10 +171,38 @@
 .vp-zoom-btn:hover { border-color: var(--border-bright); color: var(--text-0); }
 
 .vp-zoom-track {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 72px;          /* vertical slider height */
+  height: 78px;
+}
+
+.vp-zoom-marker {
+  position: absolute;
+  left: -2px;
+  right: -2px;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 0;
+  border-top: 1px dashed color-mix(in srgb, var(--accent) 65%, #fff 35%);
+  color: color-mix(in srgb, var(--accent) 78%, #fff 22%);
+  font-size: 8px;
+  font-family: var(--font-mono);
+  text-align: center;
+  line-height: 1;
+  pointer-events: none;
+}
+.vp-zoom-marker::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: -2px;
+  width: 4px;
+  height: 4px;
+  transform: translateX(-50%);
+  background: currentColor;
+  border-radius: 50%;
 }
 
 /* Vertical range slider */
@@ -163,11 +211,11 @@
   direction: rtl;
   appearance: slider-vertical;
   -webkit-appearance: slider-vertical;
-  width: 4px;
-  height: 64px;
+  width: 6px;
+  height: 70px;
   cursor: pointer;
   accent-color: var(--accent);
-  background: var(--bg-3);
+  background: transparent;
 }
 
 .vp-zoom-reset {

--- a/web/src/tabs/CubeTab.jsx
+++ b/web/src/tabs/CubeTab.jsx
@@ -32,8 +32,9 @@ function AxisIndicator({ orbitX, orbitY }) {
   const LEN    = 20;
 
   // Convert orbit angles (deg) to radians
-  const rx = (orbitX * Math.PI) / 180;
-  const ry = (orbitY * Math.PI) / 180;
+  // Indicator should follow camera orbit direction (inverse of cube rotation).
+  const rx = (-orbitX * Math.PI) / 180;
+  const ry = (-orbitY * Math.PI) / 180;
 
   // Rotation matrix: Ry then Rx (same order as CSS transform)
   const project = ([wx, wy, wz]) => {
@@ -98,6 +99,15 @@ function CubeViewerPanel() {
   const transform  = `scale(${zoom}) rotateX(${orbit.x}deg) rotateY(${orbit.y}deg)`;
   const clampZoom  = (z) => Math.max(0.4, Math.min(2.2, z));
   const zoomPct    = Math.round(zoom * 100);
+  const zoomToSlider = (value) => {
+    if (value <= 1) return ((value - 0.4) / 0.6) * 50;
+    return 50 + ((value - 1) / 1.2) * 50;
+  };
+  const sliderToZoom = (value) => {
+    if (value <= 50) return 0.4 + (value / 50) * 0.6;
+    return 1 + ((value - 50) / 50) * 1.2;
+  };
+  const sliderValue = Math.round(zoomToSlider(zoom));
 
   const onPointerDown = (e) => {
     setDrag({ x: e.clientX, y: e.clientY, ox: orbit.x, oy: orbit.y });
@@ -156,14 +166,14 @@ function CubeViewerPanel() {
             onClick={() => setShowLabels(v => !v)}
             title="면 레이블 표시/숨기기"
           >
-            <span className="vp-icon-text">F</span>
+            <span className="vp-icon-text">LBL</span>
           </button>
           <button
             className={`vp-icon-btn ${showAxes ? 'active' : ''}`}
             onClick={() => setShowAxes(v => !v)}
             title="좌표축 표시/숨기기"
           >
-            <span className="vp-icon-text">⌖</span>
+            <span className="vp-icon-text">AXIS</span>
           </button>
         </div>
 
@@ -178,12 +188,13 @@ function CubeViewerPanel() {
         <div className="vp-zoom-controls" onPointerDown={e => e.stopPropagation()}>
           <button className="vp-zoom-btn" onClick={() => setZoom(z => clampZoom(z + 0.15))} title="확대">＋</button>
           <div className="vp-zoom-track">
+            <div className="vp-zoom-marker" title="100% 기준점">100%</div>
             <input
               type="range"
               className="vp-zoom-slider"
-              min={40} max={220} step={5}
-              value={zoomPct}
-              onChange={e => setZoom(Number(e.target.value) / 100)}
+              min={0} max={100} step={1}
+              value={sliderValue}
+              onChange={e => setZoom(clampZoom(sliderToZoom(Number(e.target.value))))}
               title={`${zoomPct}%`}
             />
           </div>


### PR DESCRIPTION
### Motivation
- The axis indicator rotated opposite to the camera orbit, making orientation feedback confusing. 
- The viewport overlays (toggle buttons, axis panel, zoom controls) needed visual and spacing improvements for clarity. 
- The zoom control should treat `100%` as the natural center point and provide a visual marker for that neutral zoom.

### Description
- Invert orbit angles used by the axis projector so the indicator follows camera orbit direction by applying negative orbit angles in `AxisIndicator` (`web/src/tabs/CubeTab.jsx`).
- Remap the zoom slider to a 0–100 range with `zoomToSlider` and `sliderToZoom` helpers so the slider center (50) corresponds to `1.0x` and preserve the original zoom bounds (`0.4x`–`2.2x`) (`web/src/tabs/CubeTab.jsx`).
- Add a visible `100%` marker to the zoom track and wire the range input to the new slider mapping (`web/src/tabs/CubeTab.jsx`, `web/src/tabs/CubeTab.css`).
- Polish viewport styling and controls by updating background, borders, shadows, spacing, and toggle button presentation, and replace compact icons with clearer labels (`LBL`/`AXIS`) for the toggle pills (`web/src/tabs/CubeTab.css`).

### Testing
- Built the web bundle with `npm run build` in `web/` and the build completed successfully. 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and captured Playwright screenshots of the Cube tab for visual verification. 
- Manual UI verification confirmed axis orientation, slider behavior (center = 100%), and the new zoom marker were rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b4e3b3d8832c8ed2b6e26f749620)