### PR TITLE
Fix cube axis gizmo direction, colors, and label readability

### DIFF
--- a/web/src/tabs/CubeTab.css
+++ b/web/src/tabs/CubeTab.css
@@ -177,22 +177,25 @@
 .axis-arm-x { color: #f87171; background: currentColor; transform: translateZ(0); }
 .axis-arm-x::after { border-left: 5px solid #f87171; }
 
-.axis-arm-y { color: #4ade80; background: currentColor; transform: rotateZ(-90deg); }
-.axis-arm-y::after { border-left: 5px solid #4ade80; }
+.axis-arm-y { color: #f8fafc; background: currentColor; transform: rotateZ(-90deg); }
+.axis-arm-y::after { border-left: 5px solid #f8fafc; }
 
-.axis-arm-z { color: #60a5fa; background: currentColor; transform: rotateY(90deg); }
-.axis-arm-z::after { border-left: 5px solid #60a5fa; }
+.axis-arm-z { color: #53c87a; background: currentColor; transform: rotateY(-90deg); }
+.axis-arm-z::after { border-left: 5px solid #53c87a; }
 
 .axis-label {
   position: absolute;
   right: -12px;
   top: 50%;
   transform: translateY(-50%);
+  transform-style: preserve-3d;
   font-size: 8px;
   font-family: var(--font-mono);
   font-weight: 700;
   letter-spacing: 0.2px;
   color: currentColor;
+  text-shadow: 0 0 4px rgba(0,0,0,0.9);
+  backface-visibility: hidden;
 }
 
 .axis-origin {
@@ -250,6 +253,7 @@
   right: -2px;
   top: 50%;
   transform: translateY(-50%);
+  transform-style: preserve-3d;
   height: 0;
   border-top: 1px dashed color-mix(in srgb, var(--accent) 65%, #fff 35%);
   color: color-mix(in srgb, var(--accent) 78%, #fff 22%);

--- a/web/src/tabs/CubeTab.jsx
+++ b/web/src/tabs/CubeTab.jsx
@@ -27,13 +27,14 @@ const MOVE_BUTTONS  = [['U',"U'"],['R',"R'"],['L',"L'"],['B',"B'"]];
 // ── Axis indicator (3D gizmo, orbit-synced) ───────────────────────────────────
 function AxisIndicator({ orbitX, orbitY }) {
   const transform = `rotateX(${orbitX}deg) rotateY(${orbitY}deg)`;
+  const labelTransform = `rotateY(${-orbitY}deg) rotateX(${-orbitX}deg)`;
 
   return (
     <div className="axis-gizmo-wrap">
       <div className="axis-gizmo" style={{ transform }}>
-        <div className="axis-arm axis-arm-x"><span className="axis-label">X</span></div>
-        <div className="axis-arm axis-arm-y"><span className="axis-label">Y</span></div>
-        <div className="axis-arm axis-arm-z"><span className="axis-label">Z</span></div>
+        <div className="axis-arm axis-arm-x"><span className="axis-label" style={{ transform: `${labelTransform} translateY(-50%)` }}>X</span></div>
+        <div className="axis-arm axis-arm-y"><span className="axis-label" style={{ transform: `${labelTransform} translateY(-50%)` }}>Y</span></div>
+        <div className="axis-arm axis-arm-z"><span className="axis-label" style={{ transform: `${labelTransform} translateY(-50%)` }}>Z</span></div>
         <span className="axis-origin" />
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- The 3D axis gizmo in the cube viewer had the Z-axis pointing the wrong way and axis labels became hard to read when the view was rotated.

### Description
- Counter-rotate the axis labels so they remain facing the viewer by adding `labelTransform` and applying it to the label `style` in `web/src/tabs/CubeTab.jsx`.
- Flip the Z-axis orientation to point toward the cube F-face by changing the Z arm transform to `rotateY(-90deg)` and adjust axis colors to cube conventions (X=red, Y=white, Z=green) in `web/src/tabs/CubeTab.css`.
- Improve label readability by adding `transform-style: preserve-3d`, `text-shadow`, and `backface-visibility: hidden` to `.axis-label`, and add `transform-style: preserve-3d` to the zoom marker to stabilize rendering.

### Testing
- Ran `npm run build` in `web/` and the build completed successfully.
- Launched the dev server with `npm run dev` and executed a Playwright script that opened the dashboard, toggled the axis indicator, performed an orbit drag, and captured a screenshot showing corrected orientation, colors, and readable labels (artifact created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3cfb5c7e4832caea964adceff94a1)