### PR TITLE
Add layered eye rendering and interpolated eye params to FaceTab

### DIFF
--- a/web/src/tabs/FaceTab.jsx
+++ b/web/src/tabs/FaceTab.jsx
@@ -39,6 +39,11 @@ const EMOTION_CONFIG = {
     drift: true,
     scan: false,
     cheeks: false,
+    pupilScale: 1,
+    pupilOffsetX: 0,
+    pupilOffsetY: 0,
+    highlightOpacity: 0.35,
+    eyelidDrop: 8,
   },
   ATTENTIVE: {
     label: 'Attentive',
@@ -52,6 +57,11 @@ const EMOTION_CONFIG = {
     drift: false,
     scan: false,
     cheeks: false,
+    pupilScale: 1,
+    pupilOffsetX: 0,
+    pupilOffsetY: 0,
+    highlightOpacity: 0.45,
+    eyelidDrop: 2,
   },
   THINKING: {
     label: 'Thinking',
@@ -65,11 +75,16 @@ const EMOTION_CONFIG = {
     drift: true,
     scan: true,
     cheeks: false,
+    pupilScale: 0.95,
+    pupilOffsetX: 4,
+    pupilOffsetY: 0,
+    highlightOpacity: 0.28,
+    eyelidDrop: 4,
   },
   HAPPY: {
     label: 'Happy',
-    leftEye:  { type: 'arc', rx: 38, ry: 26, offsetY: 0 },
-    rightEye: { type: 'arc', rx: 38, ry: 26, offsetY: 0 },
+    leftEye:  { type: 'ellipse', rx: 38, ry: 26, offsetY: 0 },
+    rightEye: { type: 'ellipse', rx: 38, ry: 26, offsetY: 0 },
     leftBrow:  { dx1: -28, dy1: -44, dx2: 28, dy2: -52, curve: -8 },
     rightBrow: { dx1: -28, dy1: -52, dx2: 28, dy2: -44, curve: -8 },
     mouth: { type: 'smile', halfW: 50, startY: 0, endY: 0, curveY: 26 },
@@ -78,6 +93,11 @@ const EMOTION_CONFIG = {
     drift: false,
     scan: false,
     cheeks: true,
+    pupilScale: 0.9,
+    pupilOffsetX: 0,
+    pupilOffsetY: 1,
+    highlightOpacity: 0.85,
+    eyelidDrop: 1,
   },
 };
 
@@ -107,12 +127,20 @@ function flattenNumerics(cfg) {
     rb_dx2: cfg.rightBrow.dx2, rb_dy2: cfg.rightBrow.dy2, rb_c: cfg.rightBrow.curve,
     m_halfW: cfg.mouth.halfW, m_startY: cfg.mouth.startY,
     m_endY: cfg.mouth.endY,   m_curveY: cfg.mouth.curveY,
+    pupilScale: cfg.pupilScale,
+    pupilOffsetX: cfg.pupilOffsetX,
+    pupilOffsetY: cfg.pupilOffsetY,
+    highlightOpacity: cfg.highlightOpacity,
+    eyelidDrop: cfg.eyelidDrop,
   };
 }
 
 // ── SVG sub-components ────────────────────────────────────────────────────────
 
-function EyeShape({ x, eyeY, rx, ry, type, blinkProgress, driftX, driftY }) {
+function EyeShape({
+  x, eyeY, rx, ry, type, blinkProgress, driftX, driftY,
+  pupilScale, pupilOffsetX, pupilOffsetY, highlightOpacity, eyelidDrop,
+}) {
   const ryFinal = Math.max(1, ry * (1 - blinkProgress));
   const cx = x + driftX;
   const cy = eyeY + driftY;
@@ -128,8 +156,36 @@ function EyeShape({ x, eyeY, rx, ry, type, blinkProgress, driftX, driftY }) {
       />
     );
   }
+
+  const pupilRadius = Math.max(1.5, Math.min(rx, ryFinal) * 0.42 * pupilScale);
+  const pupilCx = cx + pupilOffsetX + driftX * 0.18;
+  const pupilCy = cy + pupilOffsetY + driftY * 0.18;
+  const upperLidY = cy - ryFinal * 0.88 + eyelidDrop;
+  const upperLidCtrlY = cy - ryFinal * 1.4 + eyelidDrop;
+
   return (
-    <ellipse cx={cx} cy={cy} rx={rx} ry={ryFinal} fill="currentColor" />
+    <g>
+      <ellipse cx={cx} cy={cy} rx={rx} ry={ryFinal} fill="#f9fbff" />
+      {ryFinal > 2 && (
+        <>
+          <circle cx={pupilCx} cy={pupilCy} r={pupilRadius} fill="#151922" />
+          <circle
+            cx={pupilCx - pupilRadius * 0.35}
+            cy={pupilCy - pupilRadius * 0.4}
+            r={Math.max(1.2, pupilRadius * 0.28)}
+            fill="#ffffff"
+            opacity={highlightOpacity}
+          />
+        </>
+      )}
+      <path
+        d={`M ${cx - rx} ${upperLidY} Q ${cx} ${upperLidCtrlY} ${cx + rx} ${upperLidY}`}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="5"
+        strokeLinecap="round"
+      />
+    </g>
   );
 }
 
@@ -327,6 +383,11 @@ function FaceCanvas({ emotion }) {
         type={dispCfg.leftEye.type}
         blinkProgress={blinkProgress}
         driftX={driftX} driftY={driftY}
+        pupilScale={vals.pupilScale}
+        pupilOffsetX={vals.pupilOffsetX}
+        pupilOffsetY={vals.pupilOffsetY}
+        highlightOpacity={vals.highlightOpacity}
+        eyelidDrop={vals.eyelidDrop}
       />
       {/* Right eye */}
       <EyeShape
@@ -335,6 +396,11 @@ function FaceCanvas({ emotion }) {
         type={dispCfg.rightEye.type}
         blinkProgress={blinkProgress}
         driftX={driftX} driftY={driftY}
+        pupilScale={vals.pupilScale}
+        pupilOffsetX={vals.pupilOffsetX}
+        pupilOffsetY={vals.pupilOffsetY}
+        highlightOpacity={vals.highlightOpacity}
+        eyelidDrop={vals.eyelidDrop}
       />
 
       {/* Brows */}


### PR DESCRIPTION
### Motivation
- Improve eye realism and allow eye-detail properties to smoothly animate between emotions by rendering sclera/pupil/highlight and an upper eyelid and driving them from emotion parameters.
- Make eye behaviors (gaze offset, pupil size, highlight strength, eyelid droop) responsive to existing emotion transitions so expressions feel cohesive.

### Description
- Added per-emotion eye parameters to `EMOTION_CONFIG`: `pupilScale`, `pupilOffsetX`, `pupilOffsetY`, `highlightOpacity`, and `eyelidDrop` and tuned values for `CALM`, `ATTENTIVE`, `THINKING`, and `HAPPY` (including stronger highlight for `HAPPY`, larger `eyelidDrop` for `CALM`, and a positive `pupilOffsetX` for `THINKING`).
- Included the new numeric fields in `flattenNumerics()` so they are lerp-interpolated by the existing morph transition loop.
- Expanded `EyeShape` in `web/src/tabs/FaceTab.jsx` to accept the new props and render layered non-arc eyes as a 3-layer composition: sclera (white ellipse), pupil (dark circle) with a highlight circle, and an upper eyelid path; preserved the original `arc` rendering path for arc-style eyes.
- Switched the `HAPPY` eye type from `arc` to `ellipse` so the layered eye details can display, and wired the interpolated `vals` to `EyeShape` props in `FaceCanvas`.

### Testing
- Ran `npm run build` in `web` and the production build completed successfully (`vite build` passed).
- Ran `npm run lint` and it failed due to unrelated, pre-existing lint errors in `web/src/panels/EventLog.jsx` (ref access during render); the failures are not caused by these changes.
- Started the dev server with `npm run dev` and captured a visual snapshot of the updated face UI via Playwright to validate the new eye layers (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e18a89f4832ca7930b04150205a9)