### PR TITLE
Refactor emotion mapping, add new face emotions, and enforce ROS emotion priority

### DIFF
--- a/web/src/core/emotion.js
+++ b/web/src/core/emotion.js
@@ -1,0 +1,48 @@
+export const DEFAULT_EMOTION = 'CALM';
+
+export const EMOTION_KEYS = Object.freeze([
+  'CALM',
+  'ATTENTIVE',
+  'THINKING',
+  'HAPPY',
+  'CURIOUS',
+  'SHY',
+  'SURPRISED',
+  'RELIEVED',
+  'SLEEPY',
+]);
+
+// State->emotion rule table (extend this map when new HRI states are added).
+export const STATE_TO_EMOTION = Object.freeze({
+  IDLE: 'CALM',
+  LISTENING: 'ATTENTIVE',
+  RESPONDING: 'THINKING',
+  NAVIGATING: 'HAPPY',
+});
+
+export const normalizeEmotionKey = (emotion) => {
+  const key = typeof emotion === 'string' ? emotion.trim().toUpperCase() : '';
+  return EMOTION_KEYS.includes(key) ? key : null;
+};
+
+export const resolveEmotionFromState = (hriState) => (
+  STATE_TO_EMOTION[hriState] || DEFAULT_EMOTION
+);
+
+/**
+ * Emotion priority policy for incoming runtime signals:
+ * 1) Manual palette override (_emotionOverride) has the highest priority.
+ * 2) /dori/hri/emotion can set emotion when payload key is valid.
+ * 3) Invalid/missing ROS emotion falls back to state-derived emotion.
+ */
+export const resolveROSOrStateEmotion = (payload, hriState) => {
+  const normalized = normalizeEmotionKey(payload?.emotion);
+  if (normalized) {
+    return { emotion: normalized, source: 'ros' };
+  }
+
+  return {
+    emotion: resolveEmotionFromState(hriState),
+    source: 'state',
+  };
+};

--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -10,6 +10,11 @@
  */
 
 import { create } from 'zustand';
+import {
+  DEFAULT_EMOTION,
+  resolveEmotionFromState,
+  resolveROSOrStateEmotion,
+} from './emotion';
 
 const FACE_KEYS = ['U', 'R', 'F', 'D', 'L', 'B'];
 const FACE_COLORS = Object.freeze({
@@ -195,16 +200,15 @@ export const useStore = create((set, get) => ({
   expression: 'NEUTRAL',
 
   // ── Emotion (robot display face) ─────────────────────────────────────────
-  emotion: 'CALM',
-  emotionSource: 'state',   // 'state' | 'override'
+  emotion: DEFAULT_EMOTION,
+  emotionSource: 'state',   // 'state' | 'ros' | 'override'
   _emotionOverride: null,   // manually set from FaceTab palette
 
   setEmotionOverride: (em) => set({ emotion: em, emotionSource: 'override', _emotionOverride: em }),
   clearEmotionOverride: () => {
     // Revert to state-driven emotion
     const { hriState } = get();
-    const STATE_TO_EMOTION = { IDLE: 'CALM', LISTENING: 'ATTENTIVE', RESPONDING: 'THINKING', NAVIGATING: 'HAPPY' };
-    set({ emotion: STATE_TO_EMOTION[hriState] || 'CALM', emotionSource: 'state', _emotionOverride: null });
+    set({ emotion: resolveEmotionFromState(hriState), emotionSource: 'state', _emotionOverride: null });
   },
 
   // ── Event Log ────────────────────────────────────────────────────────────
@@ -264,8 +268,7 @@ export const useStore = create((set, get) => ({
           });
           // Auto-update emotion from state (only if not overriding)
           if (!get()._emotionOverride) {
-            const STATE_TO_EMOTION = { IDLE: 'CALM', LISTENING: 'ATTENTIVE', RESPONDING: 'THINKING', NAVIGATING: 'HAPPY' };
-            const nextEmotion = STATE_TO_EMOTION[d.state] || 'CALM';
+            const nextEmotion = resolveEmotionFromState(d.state);
             set({ emotion: nextEmotion, emotionSource: 'state' });
           }
           addLog(LOG_TAGS.STATE, `→ ${d.state}  [${(d.state_elapsed_sec ?? 0).toFixed(1)}s]`, rawVal);
@@ -336,13 +339,19 @@ export const useStore = create((set, get) => ({
         }
 
         case '/dori/hri/emotion': {
-          const { _emotionOverride } = get();
-          // Respect manual override from palette
-          if (_emotionOverride) break;
-          const em = parsed?.emotion || 'CALM';
-          const src = parsed?.source || 'state';
-          set({ emotion: em, emotionSource: src });
-          addLog(LOG_TAGS.EXPR, `emotion: ${em} [${src}]`, rawVal);
+          const { _emotionOverride, hriState } = get();
+          // Priority policy:
+          // 1) Manual palette override is highest and blocks ROS emotion updates.
+          // 2) Without override, accept only valid ROS emotion keys.
+          // 3) Invalid/missing ROS emotion falls back to HRI-state derived emotion.
+          if (_emotionOverride) {
+            addLog(LOG_TAGS.EXPR, `emotion ignored (manual override active): ${_emotionOverride}`, rawVal);
+            break;
+          }
+
+          const { emotion, source } = resolveROSOrStateEmotion(parsed, hriState);
+          set({ emotion, emotionSource: source });
+          addLog(LOG_TAGS.EXPR, `emotion: ${emotion} [${source}]`, rawVal);
           break;
         }
 

--- a/web/src/tabs/FaceTab.jsx
+++ b/web/src/tabs/FaceTab.jsx
@@ -17,6 +17,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Panel from '../components/Panel';
 import { useStore } from '../core/store';
+import { DEFAULT_EMOTION } from '../core/emotion';
 import './FaceTab.css';
 
 // ── Single face color (always the same regardless of emotion) ─────────────────
@@ -96,9 +97,95 @@ const EMOTION_CONFIG = {
     transitionEasing: 'overshoot',
     cheeks: true,
   },
+
+  CURIOUS: {
+    label: 'Curious',
+    leftEye:  { type: 'roundedRect', width: 110, height: 86, cornerRadius: 28, tilt: -4, upperLid: 1, lowerLid: 0.96, pupilScale: 1.08, offsetY: -4 },
+    rightEye: { type: 'roundedRect', width: 110, height: 86, cornerRadius: 28, tilt: 4, upperLid: 1, lowerLid: 0.96, pupilScale: 1.08, offsetY: -4 },
+    mouth: { type: 'curve', halfW: 36, startY: 1, endY: -1, curveY: 7 },
+    showMouth: false,
+    blink: true,
+    blinkInterval: 5200,
+    blinkProfile: 'ATTENTIVE',
+    drift: true,
+    scan: true,
+    motionProfile: {
+      x: [{ amp: 7.8, speed: 1.15 }, { amp: 2.4, speed: 2.1 }],
+      y: [{ amp: 1.1, speed: 1.0 }, { amp: 0.45, speed: 1.9 }],
+    },
+    cheeks: false,
+  },
+  SHY: {
+    label: 'Shy',
+    leftEye:  { type: 'roundedRect', width: 96, height: 72, cornerRadius: 24, tilt: -1, upperLid: 0.86, lowerLid: 1, pupilScale: 0.92, offsetY: 5 },
+    rightEye: { type: 'roundedRect', width: 96, height: 72, cornerRadius: 24, tilt: 1, upperLid: 0.86, lowerLid: 1, pupilScale: 0.92, offsetY: 5 },
+    mouth: { type: 'curve', halfW: 26, startY: 5, endY: 5, curveY: 4 },
+    showMouth: false,
+    blink: true,
+    blinkInterval: 3200,
+    blinkProfile: 'CALM',
+    drift: false,
+    scan: false,
+    motionProfile: {
+      x: [{ amp: 0.9, speed: 0.92 }, { amp: 0.5, speed: 1.55 }],
+      y: [{ amp: 0.8, speed: 0.86 }, { amp: 0.42, speed: 1.34 }],
+    },
+    cheeks: true,
+  },
+  SURPRISED: {
+    label: 'Surprised',
+    leftEye:  { type: 'roundedRect', width: 118, height: 96, cornerRadius: 30, tilt: 0, upperLid: 1, lowerLid: 1, pupilScale: 1.14, offsetY: -10 },
+    rightEye: { type: 'roundedRect', width: 118, height: 96, cornerRadius: 30, tilt: 0, upperLid: 1, lowerLid: 1, pupilScale: 1.14, offsetY: -10 },
+    mouth: { type: 'curve', halfW: 20, startY: 3, endY: 3, curveY: 15 },
+    showMouth: false,
+    blink: false,
+    blinkInterval: 0,
+    blinkProfile: 'ATTENTIVE',
+    drift: false,
+    scan: false,
+    motionProfile: {
+      x: [{ amp: 0.55, speed: 1.35 }, { amp: 0.32, speed: 2.2 }],
+      y: [{ amp: 0.45, speed: 1.04 }, { amp: 0.24, speed: 1.76 }],
+    },
+    cheeks: false,
+  },
+  RELIEVED: {
+    label: 'Relieved',
+    leftEye:  { type: 'roundedRect', width: 104, height: 80, cornerRadius: 28, tilt: -2, upperLid: 0.9, lowerLid: 1, pupilScale: 0.98, offsetY: 1 },
+    rightEye: { type: 'roundedRect', width: 104, height: 80, cornerRadius: 28, tilt: 2, upperLid: 0.9, lowerLid: 1, pupilScale: 0.98, offsetY: 1 },
+    mouth: { type: 'smile', halfW: 42, startY: 2, endY: 2, curveY: 14 },
+    showMouth: false,
+    blink: true,
+    blinkInterval: 4300,
+    blinkProfile: 'CALM',
+    drift: true,
+    scan: false,
+    motionProfile: {
+      x: [{ amp: 2.6, speed: 1.06 }, { amp: 1.4, speed: 1.82 }],
+      y: [{ amp: 1.4, speed: 0.8 }, { amp: 0.62, speed: 1.24 }],
+    },
+    cheeks: false,
+  },
+  SLEEPY: {
+    label: 'Sleepy',
+    leftEye:  { type: 'roundedRect', width: 108, height: 62, cornerRadius: 26, tilt: -3, upperLid: 0.66, lowerLid: 0.95, pupilScale: 0.86, offsetY: 8 },
+    rightEye: { type: 'roundedRect', width: 108, height: 62, cornerRadius: 26, tilt: 3, upperLid: 0.66, lowerLid: 0.95, pupilScale: 0.86, offsetY: 8 },
+    mouth: { type: 'flat', halfW: 26, startY: 6, endY: 6, curveY: 0 },
+    showMouth: false,
+    blink: true,
+    blinkInterval: 2500,
+    blinkProfile: 'CALM',
+    drift: false,
+    scan: false,
+    motionProfile: {
+      x: [{ amp: 0.7, speed: 0.58 }, { amp: 0.25, speed: 0.9 }],
+      y: [{ amp: 0.55, speed: 0.5 }, { amp: 0.2, speed: 0.82 }],
+    },
+    cheeks: false,
+  },
 };
 
-const FALLBACK_EMOTION = 'CALM';
+const FALLBACK_EMOTION = DEFAULT_EMOTION;
 
 // ── SVG layout constants ──────────────────────────────────────────────────────
 const W  = 400;
@@ -521,7 +608,7 @@ export default function FaceTab() {
             <div className="face-status-row">
               <span className="face-status-key">Source</span>
               <span className={`face-status-val face-source-${emotionSource}`}>
-                {emotionSource === 'override' ? '⚡ override' : '⟳ state'}
+                {emotionSource === 'override' ? '⚡ override' : emotionSource === 'ros' ? '◎ ros' : '⟳ state'}
               </span>
             </div>
             <div className="face-status-row">


### PR DESCRIPTION
### Motivation
- Make the state->emotion mapping extensible and shared across the app so new emotion keys can be added centrally. 
- Ensure FaceTab has first-class configs for additional emotion keys so rendering does not rely on fallbacks. 
- Make ROS-driven emotion updates explicit and robust by documenting and enforcing a priority policy for incoming `/dori/hri/emotion` messages. 

### Description
- Added `web/src/core/emotion.js` which defines `DEFAULT_EMOTION`, `EMOTION_KEYS`, `STATE_TO_EMOTION` and helper functions `normalizeEmotionKey`, `resolveEmotionFromState`, and `resolveROSOrStateEmotion` for centralized emotion resolution. 
- Updated `web/src/core/store.js` to import the new emotion helpers, use `DEFAULT_EMOTION` as the default, include `ros` in `emotionSource`, and use the centralized resolvers in `manager_state` handling and `clearEmotionOverride`. 
- Implemented an explicit priority policy in the `/dori/hri/emotion` handler: manual palette override blocks ROS updates, valid ROS emotion keys are applied, and invalid/missing ROS values fall back to state-derived emotion. 
- Extended `web/src/tabs/FaceTab.jsx` `EMOTION_CONFIG` with new emotion presets `CURIOUS`, `SHY`, `SURPRISED`, `RELIEVED`, and `SLEEPY`, switched its fallback to `DEFAULT_EMOTION`, and updated the status UI to show `◎ ros` when ROS is the source. 

### Testing
- `npm --prefix web run build` completed successfully. 
- `npm --prefix web run lint` failed due to pre-existing lint errors in unrelated files (`web/src/panels/EventLog.jsx` and a warning in `web/src/tabs/CubeTab.jsx`), not introduced by these changes. 
- Dev server run plus an automated Playwright screenshot navigation of the Face tab completed successfully as a smoke validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3faac6b1c832c907196bf809eba07)