### PR TITLE
Add topic diagnostics, bandwidth/jitter tracking, and System tab diagnostics UI

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -7,7 +7,7 @@ import HRITab    from './tabs/HRITab';
 import CubeTab   from './tabs/CubeTab';
 import SystemTab from './tabs/SystemTab';
 import { useStore, TOPIC_META } from './core/store';
-import { subscribeROS } from './core/ros';
+import { fetchTopicDiagnostics, subscribeROS } from './core/ros';
 
 import HriIcon       from './assets/icons/icon-hri.svg?react';
 import FaceIcon      from './assets/icons/icon-face.svg?react';
@@ -36,14 +36,29 @@ export default function App() {
 
   const connected        = useStore(s => s.connected);
   const handleROSMessage = useStore(s => s.handleROSMessage);
+  const setTopicMeta = useStore(s => s.setTopicMeta);
 
   useEffect(() => {
     if (!connected) return;
+
+    let cancelled = false;
+    fetchTopicDiagnostics(Object.keys(TOPIC_META))
+      .then((metaMap) => {
+        if (cancelled) return;
+        Object.entries(metaMap).forEach(([topic, meta]) => setTopicMeta(topic, meta));
+      })
+      .catch(() => {
+        // rosapi may be unavailable; diagnostics panel will show N/A for metadata.
+      });
+
     const unsubs = Object.keys(TOPIC_META).map(topic =>
-      subscribeROS(topic, undefined, (val) => handleROSMessage(topic, val))
+      subscribeROS(topic, undefined, (val, rawMsg) => handleROSMessage(topic, rawMsg ?? val))
     );
-    return () => unsubs.forEach(fn => fn());
-  }, [connected, handleROSMessage]);
+    return () => {
+      cancelled = true;
+      unsubs.forEach(fn => fn());
+    };
+  }, [connected, handleROSMessage, setTopicMeta]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');

--- a/web/src/core/ros.js
+++ b/web/src/core/ros.js
@@ -48,6 +48,49 @@ export function isConnected() {
   return !!ros;
 }
 
+function callService(name, serviceType, request = {}) {
+  if (!ros) {
+    return Promise.reject(new Error('ROS is not connected.'));
+  }
+  const roslib = getROSLib();
+  const service = new roslib.Service({ ros, name, serviceType });
+  const req = new roslib.ServiceRequest(request);
+  return new Promise((resolve, reject) => {
+    service.callService(req, resolve, reject);
+  });
+}
+
+export async function fetchTopicDiagnostics(topics = []) {
+  const requested = new Set(topics);
+  const [{ topics: allTopics = [] }, { types = [] }] = await Promise.all([
+    callService('/rosapi/topics', 'rosapi/Topics', {}),
+    callService('/rosapi/topics_and_raw_types', 'rosapi/TopicsAndRawTypes', {}),
+  ]);
+
+  const topicToType = allTopics.reduce((acc, topic, idx) => {
+    acc[topic] = types[idx] || null;
+    return acc;
+  }, {});
+
+  const sourceTopics = requested.size ? [...requested] : allTopics;
+  const validTopics = sourceTopics.filter((topic) => allTopics.includes(topic));
+
+  const [publishers, subscribers] = await Promise.all([
+    Promise.all(validTopics.map((topic) => callService('/rosapi/publishers', 'rosapi/Publishers', { topic }))),
+    Promise.all(validTopics.map((topic) => callService('/rosapi/subscribers', 'rosapi/Subscribers', { topic }))),
+  ]);
+
+  return validTopics.reduce((acc, topic, idx) => {
+    acc[topic] = {
+      msgType: topicToType[topic] || null,
+      pubCount: publishers[idx]?.publishers?.length ?? 0,
+      subCount: subscribers[idx]?.subscribers?.length ?? 0,
+      qosSummary: 'N/A (rosbridge)',
+    };
+    return acc;
+  }, {});
+}
+
 // ─── Subscribe ──────────────────────────────────────────────────────────────
 /**
  * Subscribe to a ROS topic.
@@ -79,7 +122,7 @@ function _subscribe(topic, msgType) {
   const sub = new roslib.Topic({ ros, name: topic, messageType: type });
   sub.subscribe(msg => {
     const val = msg.data !== undefined ? msg.data : msg;
-    listeners[topic]?.forEach(cb => cb(val));
+    listeners[topic]?.forEach(cb => cb(val, msg));
   });
   subscribers[topic] = sub;
 }

--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -150,6 +150,46 @@ export const TOPIC_META = {
 };
 
 const MAX_LOG = 300;
+const TOPIC_HZ_WINDOW_MS = 2000;
+const TOPIC_STATS_WINDOW_MS = 10000;
+
+const toNumberOrNull = (v) => (Number.isFinite(v) ? +v.toFixed(2) : null);
+
+function computeTopicStats(samples) {
+  if (!samples?.length) {
+    return {
+      avgHz: null,
+      jitterMs: null,
+      bwBps: null,
+      avgMsgBytes: null,
+    };
+  }
+
+  const firstTs = samples[0].ts;
+  const lastTs = samples[samples.length - 1].ts;
+  const durationSec = (lastTs - firstTs) / 1000;
+  const totalBytes = samples.reduce((acc, s) => acc + s.size, 0);
+  const avgMsgBytes = totalBytes / samples.length;
+
+  const intervals = [];
+  for (let i = 1; i < samples.length; i += 1) {
+    intervals.push(samples[i].ts - samples[i - 1].ts);
+  }
+
+  const meanInterval = intervals.length
+    ? intervals.reduce((acc, v) => acc + v, 0) / intervals.length
+    : null;
+  const variance = meanInterval && intervals.length > 1
+    ? intervals.reduce((acc, v) => acc + ((v - meanInterval) ** 2), 0) / intervals.length
+    : null;
+
+  return {
+    avgHz: durationSec > 0 ? toNumberOrNull(samples.length / durationSec) : null,
+    jitterMs: variance !== null ? toNumberOrNull(Math.sqrt(variance)) : null,
+    bwBps: durationSec > 0 ? toNumberOrNull(totalBytes / durationSec) : null,
+    avgMsgBytes: toNumberOrNull(avgMsgBytes),
+  };
+}
 
 // ─── Store ───────────────────────────────────────────────────────────────────
 export const useStore = create((set, get) => ({
@@ -231,21 +271,56 @@ export const useStore = create((set, get) => ({
   // ── Topic Hz tracking ───────────────────────────────────────────────────
   topicHz: {},   // topic -> number (msgs/sec, rolling 2s)
   _topicTimes: {}, // topic -> timestamp[]
+  topicStats: {}, // topic -> diagnostics info
+  _topicSamples: {}, // topic -> [{ ts, size }] (rolling 10s)
 
-  recordTopicHit: (topic) => {
+  setTopicMeta: (topic, meta = {}) => {
+    set((s) => ({
+      topicStats: {
+        ...s.topicStats,
+        [topic]: {
+          msgType: meta.msgType ?? s.topicStats[topic]?.msgType ?? null,
+          pubCount: meta.pubCount ?? s.topicStats[topic]?.pubCount ?? null,
+          subCount: meta.subCount ?? s.topicStats[topic]?.subCount ?? null,
+          qosSummary: meta.qosSummary ?? s.topicStats[topic]?.qosSummary ?? 'N/A (rosbridge)',
+          ...s.topicStats[topic],
+          ...meta,
+        },
+      },
+    }));
+  },
+
+  recordTopicHit: (topic, msgPayload) => {
     const now = Date.now();
     const times = [...(get()._topicTimes[topic] || []), now]
-      .filter(t => now - t < 2000);
+      .filter(t => now - t < TOPIC_HZ_WINDOW_MS);
+    const msgBytes = JSON.stringify(msgPayload ?? null)?.length ?? 0;
+    const samples = [...(get()._topicSamples[topic] || []), { ts: now, size: msgBytes }]
+      .filter(({ ts }) => now - ts < TOPIC_STATS_WINDOW_MS);
+    const stats = computeTopicStats(samples);
+
     set(s => ({
       _topicTimes: { ...s._topicTimes, [topic]: times },
+      _topicSamples: { ...s._topicSamples, [topic]: samples },
       topicHz:     { ...s.topicHz, [topic]: +(times.length / 2).toFixed(1) },
+      topicStats: {
+        ...s.topicStats,
+        [topic]: {
+          msgType: s.topicStats[topic]?.msgType ?? null,
+          pubCount: s.topicStats[topic]?.pubCount ?? null,
+          subCount: s.topicStats[topic]?.subCount ?? null,
+          qosSummary: s.topicStats[topic]?.qosSummary ?? 'N/A (rosbridge)',
+          ...stats,
+          lastSeenMs: now,
+        },
+      },
     }));
   },
 
   // ── Master message handler ───────────────────────────────────────────────
   handleROSMessage: (topic, rawVal) => {
     const { addLog, recordTopicHit } = get();
-    recordTopicHit(topic);
+    recordTopicHit(topic, rawVal);
 
     let parsed = rawVal;
     if (typeof rawVal === 'string') {

--- a/web/src/tabs/SystemTab.css
+++ b/web/src/tabs/SystemTab.css
@@ -7,54 +7,6 @@
   overflow: hidden;
 }
 
-.sys-hz-list {
-  padding: 8px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.sys-hz-row {
-  display: grid;
-  grid-template-columns: 52px 240px 1fr 52px;
-  align-items: center;
-  gap: 8px;
-  padding: 3px 0;
-}
-
-.sys-hz-tag {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-}
-
-.sys-hz-topic {
-  font-size: 10px;
-  color: var(--text-1);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.sys-hz-bar-wrap {
-  height: 4px;
-  background: var(--bg-3);
-  border-radius: 2px;
-  overflow: hidden;
-}
-.sys-hz-bar {
-  height: 100%;
-  background: var(--accent);
-  border-radius: 2px;
-  transition: width 0.5s ease;
-  opacity: 0.7;
-}
-
-.sys-hz-val {
-  font-size: 10px;
-  color: var(--text-1);
-  text-align: right;
-}
 
 .sys-info {
   padding: 12px;
@@ -78,16 +30,56 @@
     align-content: start;
   }
 
-  .sys-hz-row {
-    grid-template-columns: 50px minmax(0, 1fr) 64px;
-    grid-template-areas:
-      "tag topic val"
-      "bar bar bar";
-    row-gap: 4px;
-  }
+}
 
-  .sys-hz-tag { grid-area: tag; }
-  .sys-hz-topic { grid-area: topic; }
-  .sys-hz-bar-wrap { grid-area: bar; }
-  .sys-hz-val { grid-area: val; }
+.sys-topic-diag {
+  padding: 8px 12px 0;
+}
+
+.sys-topic-diag-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: 6px;
+}
+
+
+.sys-tooltip {
+  font-size: 12px;
+  color: var(--text-1);
+  cursor: help;
+}
+
+.sys-topic-diag-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--bg-3);
+  border-radius: 6px;
+  max-height: 420px;
+}
+
+.sys-topic-diag-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 10px;
+}
+
+.sys-topic-diag-table th,
+.sys-topic-diag-table td {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--bg-3);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.sys-topic-diag-table th {
+  position: sticky;
+  top: 0;
+  background: var(--bg-2);
+  z-index: 1;
+}
+
+.sys-topic-cell {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/web/src/tabs/SystemTab.jsx
+++ b/web/src/tabs/SystemTab.jsx
@@ -1,36 +1,75 @@
+import { useEffect, useState } from 'react';
 import Panel from '../components/Panel';
 import { useStore, TOPIC_META } from '../core/store';
 import { parseWsUrl } from '../core/url';
 import './SystemTab.css';
 
+const fmt = (val, suffix = '') => (val === null || val === undefined ? 'N/A' : `${val}${suffix}`);
+
 export default function SystemTab() {
-  const topicHz  = useStore(s => s.topicHz);
-  const connected = useStore(s => s.connected);
-  const isDemoMode = useStore(s => s.isDemoMode);
-  const wsUrl = useStore(s => s.wsUrl);
+  const topicStats = useStore((s) => s.topicStats);
+  const connected = useStore((s) => s.connected);
+  const isDemoMode = useStore((s) => s.isDemoMode);
+  const wsUrl = useStore((s) => s.wsUrl);
 
   const topics = Object.keys(TOPIC_META);
   const parsedWsUrl = parseWsUrl(wsUrl);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
 
   return (
     <div className="sys-layout">
-      <Panel title="Topic Hz Monitor">
-        <div className="sys-hz-list">
-          {topics.map(topic => {
-            const hz  = topicHz[topic] ?? 0;
-            const meta = TOPIC_META[topic];
-            const pct  = Math.min(hz / 30, 1) * 100;
-            return (
-              <div key={topic} className="sys-hz-row">
-                <span className={`sys-hz-tag tag-${meta.tag}`}>{meta.tag}</span>
-                <span className="sys-hz-topic">{topic}</span>
-                <div className="sys-hz-bar-wrap">
-                  <div className="sys-hz-bar" style={{ width: `${pct}%` }} />
-                </div>
-                <span className="sys-hz-val">{hz} Hz</span>
-              </div>
-            );
-          })}
+      <Panel title="Topic Diagnostics">
+        <div className="sys-topic-diag">
+          <div className="sys-topic-diag-header">
+            <span
+              className="sys-tooltip"
+              title="Estimated bandwidth (B/s) = total JSON payload bytes / rolling window seconds. Payload bytes use JSON.stringify(msg).length."
+            >
+              ⓘ
+            </span>
+          </div>
+
+          <div className="sys-topic-diag-table-wrap">
+            <table className="sys-topic-diag-table">
+              <thead>
+                <tr>
+                  <th>Topic</th>
+                  <th>Type</th>
+                  <th>Pub/Sub</th>
+                  <th>Avg Hz</th>
+                  <th>Jitter</th>
+                  <th>BW (B/s)</th>
+                  <th>Avg Msg</th>
+                  <th>QoS</th>
+                  <th>Last Seen</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topics.map((topic) => {
+                  const stat = topicStats[topic] || {};
+                  const lastSeenText = stat.lastSeenMs ? `${Math.max(0, Math.round((nowMs - stat.lastSeenMs) / 1000))}s ago` : 'N/A';
+                  return (
+                    <tr key={`diag-${topic}`}>
+                      <td className="sys-topic-cell">{topic}</td>
+                      <td>{fmt(stat.msgType)}</td>
+                      <td>{`${fmt(stat.pubCount)}/${fmt(stat.subCount)}`}</td>
+                      <td>{fmt(stat.avgHz)}</td>
+                      <td>{fmt(stat.jitterMs, ' ms')}</td>
+                      <td>{fmt(stat.bwBps)}</td>
+                      <td>{fmt(stat.avgMsgBytes, ' B')}</td>
+                      <td>{fmt(stat.qosSummary)}</td>
+                      <td>{lastSeenText}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         </div>
       </Panel>
 


### PR DESCRIPTION
### Motivation
- Provide richer topic diagnostics (message type, pub/sub counts, avg Hz, jitter, bandwidth, avg size) to help monitor ROS topics in the UI.
- Retrieve topic metadata from rosapi when available so diagnostics can show message types and publisher/subscriber counts.
- Replace the simple Hz monitor with a diagnostics table in the System tab for clearer visibility and troubleshooting.

### Description
- Added `callService` and `fetchTopicDiagnostics` to `core/ros.js` to query `/rosapi/topics`, `/rosapi/topics_and_raw_types`, `/rosapi/publishers`, and `/rosapi/subscribers`, and return a per-topic metadata map.
- Updated `subscribeROS` to forward the raw ROS message to listeners and adapted `App.jsx` to call `fetchTopicDiagnostics` on connect and populate store metadata via `setTopicMeta`.
- Extended the store (`core/store.js`) with rolling sample buffers and `computeTopicStats` to calculate `avgHz`, `jitterMs`, `bwBps`, and `avgMsgBytes`, and added `topicStats`, `_topicSamples`, and `setTopicMeta`; `recordTopicHit` now records payload sizes and updates diagnostics.
- Reworked `SystemTab.jsx` and `SystemTab.css` to show a diagnostics table with columns for type, pub/sub, avg Hz, jitter, bandwidth, avg message size, QoS, and last-seen timestamp, and added a 1s clock for the "last seen" display.

### Testing
- Ran `npm run build` for the web app and the production build completed successfully.
- Ran `npm run lint` and static linting passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b438514a10832cb5201aed691b811b)