### PR TITLE
Add Topic Publisher panel to SystemTab with allowlist, safety confirmation, and store status

### DIFF
--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -265,6 +265,11 @@ export const useStore = create((set, get) => ({
   // Each entry: { id, ts, tag, text, raw? }
   log: [],
 
+  // ── Topic Publisher Status ───────────────────────────────────────────────
+  isPublishing: false,
+  lastPublishAt: null,
+  publishError: null,
+
   addLog: (tag, text, raw = null) => {
     const entry = {
       id:  Date.now() + Math.random(),
@@ -277,6 +282,12 @@ export const useStore = create((set, get) => ({
   },
 
   clearLog: () => set({ log: [] }),
+
+  setPublishState: ({ isPublishing, lastPublishAt, publishError } = {}) => set((s) => ({
+    isPublishing: typeof isPublishing === 'boolean' ? isPublishing : s.isPublishing,
+    lastPublishAt: lastPublishAt === undefined ? s.lastPublishAt : lastPublishAt,
+    publishError: publishError === undefined ? s.publishError : publishError,
+  })),
 
   // ── Topic Hz tracking ───────────────────────────────────────────────────
   topicHz: {},   // topic -> number (msgs/sec, rolling 2s)

--- a/web/src/tabs/SystemTab.css
+++ b/web/src/tabs/SystemTab.css
@@ -119,3 +119,112 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.sys-publisher {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+}
+
+.sys-pub-row {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 8px;
+  align-items: center;
+  font-size: 11px;
+}
+
+.sys-pub-row-column {
+  grid-template-columns: 1fr;
+}
+
+.sys-publisher input,
+.sys-publisher select,
+.sys-publisher textarea {
+  width: 100%;
+  background: var(--bg-2);
+  border: 1px solid var(--bg-3);
+  color: var(--text-0);
+  border-radius: 6px;
+  padding: 6px;
+  font-size: 11px;
+}
+
+.sys-pub-mode-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 11px;
+}
+
+.sys-pub-mode-row input[type="number"] {
+  width: 90px;
+}
+
+.sys-pub-actions {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.sys-pub-actions button {
+  background: var(--bg-2);
+  border: 1px solid var(--bg-3);
+  color: var(--text-0);
+  border-radius: 6px;
+  font-size: 11px;
+  padding: 7px 10px;
+  cursor: pointer;
+}
+
+.sys-pub-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sys-pub-status {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 10px;
+  color: var(--text-1);
+}
+
+.sys-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.sys-confirm-modal {
+  width: min(420px, 92vw);
+  border-radius: 10px;
+  border: 1px solid var(--bg-3);
+  background: var(--bg-1);
+  padding: 14px;
+}
+
+.sys-confirm-modal h4 {
+  margin: 0 0 8px;
+}
+
+.sys-confirm-modal p {
+  margin: 0 0 12px;
+  font-size: 12px;
+}
+
+.sys-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.sys-confirm-actions .danger {
+  border-color: var(--red);
+  color: var(--red);
+}

--- a/web/src/tabs/SystemTab.jsx
+++ b/web/src/tabs/SystemTab.jsx
@@ -1,10 +1,21 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Panel from '../components/Panel';
-import { useStore, TOPIC_META } from '../core/store';
+import { LOG_TAGS, TOPIC_META, useStore } from '../core/store';
+import { publishROS } from '../core/ros';
 import { parseWsUrl } from '../core/url';
 import './SystemTab.css';
 
 const fmt = (val, suffix = '') => (val === null || val === undefined ? 'N/A' : `${val}${suffix}`);
+const DANGEROUS_TOPICS = new Set(['/cmd_vel', '/cmd_vel_mux/input/teleop', '/dori/nav/command']);
+const ALLOWED_TOPICS = [
+  '/dori/nav/command',
+  '/dori/hri/interaction_trigger',
+  '/dori/hri/gesture_command',
+  '/dori/hri/expression_command',
+  '/dori/tts/text',
+  '/dori/llm/query',
+  '/cmd_vel',
+];
 
 const thresholdClass = (value, warningThreshold) => {
   if (value === null || value === undefined) return '';
@@ -17,15 +28,128 @@ export default function SystemTab() {
   const isDemoMode = useStore((s) => s.isDemoMode);
   const wsUrl = useStore((s) => s.wsUrl);
   const systemMetrics = useStore((s) => s.systemMetrics);
+  const isPublishing = useStore((s) => s.isPublishing);
+  const lastPublishAt = useStore((s) => s.lastPublishAt);
+  const publishError = useStore((s) => s.publishError);
+  const addLog = useStore((s) => s.addLog);
+  const setPublishState = useStore((s) => s.setPublishState);
 
   const topics = Object.keys(TOPIC_META);
   const parsedWsUrl = parseWsUrl(wsUrl);
   const [nowMs, setNowMs] = useState(() => Date.now());
+  const [topic, setTopic] = useState('/dori/nav/command');
+  const [msgType, setMsgType] = useState('std_msgs/String');
+  const [jsonPayload, setJsonPayload] = useState('{"data":"hello"}');
+  const [mode, setMode] = useState('once');
+  const [rateHz, setRateHz] = useState('1');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const intervalRef = useRef(null);
+
+  const canPublish = connected || isDemoMode;
+  const rateValue = Number(rateHz);
+  const isRateValid = Number.isFinite(rateValue) && rateValue > 0;
+  const isTopicAllowed = useMemo(() => ALLOWED_TOPICS.includes(topic), [topic]);
+
+  const stopPeriodic = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setPublishState({ isPublishing: false });
+  }, [setPublishState]);
+
+  const publishOnce = useCallback(() => {
+    if (!isTopicAllowed) {
+      const err = `Blocked by allowlist: ${topic}`;
+      setPublishState({ publishError: err, isPublishing: false });
+      addLog(LOG_TAGS.ERROR, err);
+      return false;
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(jsonPayload);
+    } catch (e) {
+      const err = `Invalid JSON payload: ${e.message}`;
+      setPublishState({ publishError: err, isPublishing: false });
+      addLog(LOG_TAGS.ERROR, err);
+      return false;
+    }
+
+    if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+      const err = 'Payload type mismatch: ROS message payload must be a JSON object.';
+      setPublishState({ publishError: err, isPublishing: false });
+      addLog(LOG_TAGS.ERROR, err);
+      return false;
+    }
+
+    if (!msgType.includes('/')) {
+      const err = `Message type mismatch: "${msgType}" is invalid. Use format like pkg/Type.`;
+      setPublishState({ publishError: err, isPublishing: false });
+      addLog(LOG_TAGS.ERROR, err);
+      return false;
+    }
+
+    try {
+      publishROS(topic, msgType, payload);
+      setPublishState({ lastPublishAt: Date.now(), publishError: null });
+      return true;
+    } catch (e) {
+      const err = `Publish failed: ${e.message}`;
+      setPublishState({ publishError: err, isPublishing: false });
+      addLog(LOG_TAGS.ERROR, err);
+      return false;
+    }
+  }, [addLog, isTopicAllowed, jsonPayload, msgType, setPublishState, topic]);
+
+  const startPeriodic = useCallback(() => {
+    if (!isRateValid) {
+      const err = `Invalid rateHz: ${rateHz}`;
+      setPublishState({ publishError: err, isPublishing: false });
+      addLog(LOG_TAGS.ERROR, err);
+      return;
+    }
+
+    stopPeriodic();
+    const tickMs = Math.max(20, Math.round(1000 / rateValue));
+    setPublishState({ isPublishing: true, publishError: null });
+
+    const ok = publishOnce();
+    if (!ok) {
+      stopPeriodic();
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      const successful = publishOnce();
+      if (!successful) stopPeriodic();
+    }, tickMs);
+  }, [addLog, isRateValid, publishOnce, rateHz, rateValue, setPublishState, stopPeriodic]);
+
+  const handlePublishClick = () => {
+    if (!canPublish) return;
+    if (DANGEROUS_TOPICS.has(topic) && !confirmOpen) {
+      setConfirmOpen(true);
+      return;
+    }
+    if (mode === 'once') {
+      stopPeriodic();
+      publishOnce();
+      return;
+    }
+    if (isPublishing) {
+      stopPeriodic();
+      return;
+    }
+    startPeriodic();
+  };
 
   useEffect(() => {
     const timer = setInterval(() => setNowMs(Date.now()), 1000);
     return () => clearInterval(timer);
   }, []);
+
+  useEffect(() => () => stopPeriodic(), [stopPeriodic]);
 
   return (
     <div className="sys-layout">
@@ -51,6 +175,61 @@ export default function SystemTab() {
             <div className="sys-metric-row"><span>Usage</span><span className={thresholdClass(systemMetrics?.ram?.usage_pct, 85)}>{fmt(systemMetrics?.ram?.usage_pct, '%')}</span></div>
             <div className="sys-metric-row"><span>Used</span><span className="sys-metric-value">{fmt(systemMetrics?.ram?.used_mb, ' MB')}</span></div>
             <div className="sys-metric-row"><span>Total</span><span className="sys-metric-value">{fmt(systemMetrics?.ram?.total_mb, ' MB')}</span></div>
+          </div>
+        </div>
+      </Panel>
+
+      <Panel title="Topic Publisher">
+        <div className="sys-publisher">
+          <div className="sys-pub-row">
+            <label htmlFor="sys-pub-topic">Topic</label>
+            <select id="sys-pub-topic" value={topic} onChange={(e) => setTopic(e.target.value)}>
+              {ALLOWED_TOPICS.map((allowed) => <option key={allowed} value={allowed}>{allowed}</option>)}
+            </select>
+          </div>
+
+          <div className="sys-pub-row">
+            <label htmlFor="sys-pub-type">msgType</label>
+            <input id="sys-pub-type" value={msgType} onChange={(e) => setMsgType(e.target.value)} placeholder="std_msgs/String" />
+          </div>
+
+          <div className="sys-pub-row sys-pub-row-column">
+            <label htmlFor="sys-pub-payload">JSON payload</label>
+            <textarea
+              id="sys-pub-payload"
+              value={jsonPayload}
+              onChange={(e) => setJsonPayload(e.target.value)}
+              rows={6}
+              spellCheck={false}
+            />
+          </div>
+
+          <div className="sys-pub-mode-row">
+            <label><input type="radio" name="sys-pub-mode" checked={mode === 'once'} onChange={() => setMode('once')} /> once</label>
+            <label><input type="radio" name="sys-pub-mode" checked={mode === 'periodic'} onChange={() => setMode('periodic')} /> periodic</label>
+            <label htmlFor="sys-pub-rate">rateHz</label>
+            <input
+              id="sys-pub-rate"
+              type="number"
+              min="0.1"
+              step="0.1"
+              value={rateHz}
+              onChange={(e) => setRateHz(e.target.value)}
+              disabled={mode !== 'periodic'}
+            />
+          </div>
+
+          <div className="sys-pub-actions">
+            <button type="button" disabled={!canPublish} onClick={handlePublishClick}>
+              {mode === 'periodic' ? (isPublishing ? 'Stop Publishing' : 'Start Publishing') : 'Publish Once'}
+            </button>
+            <div className="sys-pub-status">
+              <span>isPublishing: {isPublishing ? 'YES' : 'NO'}</span>
+              <span>lastPublishAt: {lastPublishAt ? new Date(lastPublishAt).toLocaleTimeString() : 'N/A'}</span>
+              <span style={{ color: publishError ? 'var(--red)' : 'var(--text-1)' }}>
+                publishError: {publishError || 'none'}
+              </span>
+            </div>
           </div>
         </div>
       </Panel>
@@ -82,12 +261,12 @@ export default function SystemTab() {
                 </tr>
               </thead>
               <tbody>
-                {topics.map((topic) => {
-                  const stat = topicStats[topic] || {};
+                {topics.map((diagTopic) => {
+                  const stat = topicStats[diagTopic] || {};
                   const lastSeenText = stat.lastSeenMs ? `${Math.max(0, Math.round((nowMs - stat.lastSeenMs) / 1000))}s ago` : 'N/A';
                   return (
-                    <tr key={`diag-${topic}`}>
-                      <td className="sys-topic-cell">{topic}</td>
+                    <tr key={`diag-${diagTopic}`}>
+                      <td className="sys-topic-cell">{diagTopic}</td>
                       <td>{fmt(stat.msgType)}</td>
                       <td>{`${fmt(stat.pubCount)}/${fmt(stat.subCount)}`}</td>
                       <td>{fmt(stat.avgHz)}</td>
@@ -151,6 +330,39 @@ export default function SystemTab() {
           )}
         </div>
       </Panel>
+
+      {confirmOpen && (
+        <div className="sys-confirm-overlay" role="dialog" aria-modal="true">
+          <div className="sys-confirm-modal">
+            <h4>Dangerous Topic Confirmation</h4>
+            <p>
+              Topic <code>{topic}</code> may cause robot motion or unsafe behavior. Continue publish?
+            </p>
+            <div className="sys-confirm-actions">
+              <button type="button" onClick={() => setConfirmOpen(false)}>Cancel</button>
+              <button
+                type="button"
+                className="danger"
+                onClick={() => {
+                  setConfirmOpen(false);
+                  if (mode === 'once') {
+                    stopPeriodic();
+                    publishOnce();
+                    return;
+                  }
+                  if (isPublishing) {
+                    stopPeriodic();
+                    return;
+                  }
+                  startPeriodic();
+                }}
+              >
+                Confirm Publish
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a safe, visible way to publish test ROS messages from the System tab with both one-shot and periodic modes.
- Surface publisher status and errors in the UI so users know when publishes succeed/fail.
- Prevent accidental publishes to motion/critical topics by enforcing an allowlist and requiring confirmation for dangerous topics.

### Description
- Added a new "Topic Publisher" panel to `web/src/tabs/SystemTab.jsx` with inputs for `topic`, `msgType`, JSON `payload`, `once|periodic` mode, and `rateHz`, plus publish controls and status readouts.  
- Reused `publishROS` from `web/src/core/ros.js` for all sends and implemented periodic publishing using `setInterval` with proper lifecycle cleanup via refs and `useEffect`/`useCallback`.  
- Extended the Zustand store in `web/src/core/store.js` with publisher state fields `isPublishing`, `lastPublishAt`, `publishError` and a `setPublishState` action to drive UI feedback.  
- Validates inputs (JSON parse, payload type, `msgType` format, rate) and records any validation or publish errors to the event log using `LOG_TAGS.ERROR`.  
- Enforced a topic allowlist and added a confirmation modal for dangerous topics (e.g. `/cmd_vel`) to require explicit user consent before publishing.  
- Added styling for the new panel and modal in `web/src/tabs/SystemTab.css`.

### Testing
- Linted the modified files with `cd web && npx eslint src/tabs/SystemTab.jsx src/core/store.js` and fixed issues in the touched files; that check passed for those files.  
- Built the app with `cd web && npm run build` which succeeded and produced a production artifact.  
- Ran `cd web && npm run lint`; this run failed due to existing unrelated lint errors elsewhere in the repo (`web/src/panels/EventLog.jsx`, `web/src/tabs/CubeTab.jsx`) and not caused by these changes.  
- Attempted a headless UI screenshot with Playwright which failed due to a Chromium crash in the environment; the dev-server was reachable but the browser run failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44e0f6d68832ca3a34774c8c64ace)