### PR TITLE
feat(web): compute default wsUrl from browser context with query/localStorage overrides

### DIFF
--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -222,17 +222,62 @@ function parseBoolPayload(value) {
   return false;
 }
 
+const DEFAULT_WS_PORT = '9090';
+const WS_URL_STORAGE_KEY = 'wsUrl';
+const WS_URL_QUERY_KEYS = ['wsUrl', 'ws_url', 'ws'];
+
+function resolveWsUrlOverrideFromQuery(search) {
+  if (!search) return null;
+
+  const params = new URLSearchParams(search);
+  for (const key of WS_URL_QUERY_KEYS) {
+    const candidate = params.get(key)?.trim();
+    if (candidate) return candidate;
+  }
+  return null;
+}
+
+function isValidWsUrl(url) {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return ['ws:', 'wss:'].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function getDefaultWsUrl() {
+  const fallback = `ws://localhost:${DEFAULT_WS_PORT}`;
+  if (typeof window === 'undefined') return fallback;
+
+  const queryOverride = resolveWsUrlOverrideFromQuery(window.location?.search);
+  if (isValidWsUrl(queryOverride)) return queryOverride;
+
+  const localStorageOverride = window.localStorage?.getItem(WS_URL_STORAGE_KEY)?.trim();
+  if (isValidWsUrl(localStorageOverride)) return localStorageOverride;
+
+  const protocol = window.location?.protocol === 'https:' ? 'wss' : 'ws';
+  const hostname = window.location?.hostname || 'localhost';
+  return `${protocol}://${hostname}:${DEFAULT_WS_PORT}`;
+}
+
 // ─── Store ───────────────────────────────────────────────────────────────────
 export const useStore = create((set, get) => ({
 
   // ── Connection ──────────────────────────────────────────────────────────
   connected: false,
   isDemoMode: false,
-  wsUrl: 'ws://localhost:9090',
+  wsUrl: getDefaultWsUrl(),
 
   setConnected: (v) => set({ connected: v }),
   setDemoMode:  (v) => set({ isDemoMode: v }),
-  setWsUrl:     (v) => set({ wsUrl: v }),
+  setWsUrl:     (v) => {
+    if (typeof window !== 'undefined' && typeof v === 'string') {
+      window.localStorage?.setItem(WS_URL_STORAGE_KEY, v);
+    }
+    set({ wsUrl: v });
+  },
 
   // ── Cube Sim ────────────────────────────────────────────────────────────
   cubeState: createSolvedCube(),


### PR DESCRIPTION
### Motivation
- Replace the hardcoded WebSocket URL in the store so the app can derive an appropriate default at runtime for browser and SSR environments.
- Allow easy overrides via query string or `localStorage` so developers and users can point the dashboard at different rosbridge endpoints without editing code.

### Description
- Added helpers and constants: `DEFAULT_WS_PORT`, `WS_URL_STORAGE_KEY`, `WS_URL_QUERY_KEYS`, `resolveWsUrlOverrideFromQuery()`, `isValidWsUrl()`, and `getDefaultWsUrl()` in `web/src/core/store.js` to compute the initial URL.
- `getDefaultWsUrl()` returns a safe SSR fallback of `ws://localhost:9090`, returns a query override if present and valid, then a `localStorage` override if present and valid, otherwise computes `protocol://hostname:9090` where `protocol` is `wss` when `window.location.protocol === 'https:'` and `ws` otherwise.
- Replaced the hardcoded `wsUrl` default with `wsUrl: getDefaultWsUrl()` and extended `setWsUrl` to persist browser updates into `localStorage` under the `wsUrl` key to align with `Header.jsx` which initializes its input with `useState(wsUrl)` and calls `setWsUrl(urlInput)` on connect.

### Testing
- Ran lint with `npm --prefix web run lint`; the lint run failed due to pre-existing, unrelated errors elsewhere in the codebase (e.g., `HRITab.jsx`, `EventLog.jsx`, `KnowledgeTab.jsx`, `TopicPublisher.jsx`) while the change in `web/src/core/store.js` is isolated and does not introduce new lint errors in that file.
- Verified the store now exposes a dynamic `wsUrl` default and that `setWsUrl` will persist updates to `localStorage` in browser environments (manual code inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b47a5cee1c832c95a62d4140d95a88)