### PR TITLE
Fix dashboard publish crash when roslib.Message is unavailable

### DIFF
--- a/web/src/core/ros.js
+++ b/web/src/core/ros.js
@@ -141,5 +141,6 @@ export function publishROS(topic, msgType, data) {
   if (!ros) return;
   const roslib = getROSLib();
   const t = new roslib.Topic({ ros, name: topic, messageType: msgType });
-  t.publish(new roslib.Message(data));
+  const message = typeof roslib.Message === 'function' ? new roslib.Message(data) : data;
+  t.publish(message);
 }


### PR DESCRIPTION
### Motivation
- The dashboard publish path crashed when `roslib.Message` was not exposed as a constructor by the bundled/runtime `roslib`, so publishing should gracefully handle both shapes.

### Description
- Update `publishROS` in `web/src/core/ros.js` to only call `new roslib.Message(data)` when `roslib.Message` is a function, otherwise publish the raw `data` payload as a compatibility fallback.

### Testing
- Ran `npm run build` in `web/` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b65807796c832caaa988e649d53a58)