### PR TITLE
Unify dashboard frontend and API on single origin and remove hardcoded tunnel API port

### DIFF
--- a/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -14,7 +14,7 @@ Endpoints:
 
 Usage:
   pip install fastapi uvicorn python-multipart
-  python3 knowledge_api.py [--port 3001] [--repo-root /path/to/dori]
+  python3 knowledge_api.py [--port 3000] [--repo-root /path/to/dori] [--web-dir /path/to/web]
 """
 
 import argparse
@@ -33,6 +33,7 @@ from pathlib import Path
 from fastapi import FastAPI, File, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 # ── Path resolution ────────────────────────────────────────────────────────────
 
@@ -48,7 +49,8 @@ DEFAULT_REPO = find_repo_root(Path(__file__).resolve().parent)
 
 parser_arg = argparse.ArgumentParser(add_help=False)
 parser_arg.add_argument('--repo-root', default=str(DEFAULT_REPO))
-parser_arg.add_argument('--port', type=int, default=3001)
+parser_arg.add_argument('--port', type=int, default=3000)
+parser_arg.add_argument('--web-dir', default='')
 args, _ = parser_arg.parse_known_args()
 
 REPO_ROOT   = Path(args.repo_root)
@@ -74,6 +76,20 @@ app.add_middleware(
     allow_methods=['*'],
     allow_headers=['*'],
 )
+
+
+def _resolve_web_dir() -> Path | None:
+    if args.web_dir:
+        candidate = Path(args.web_dir).expanduser().resolve()
+        if candidate.is_dir():
+            return candidate
+
+    fallback = Path(__file__).resolve().parents[2] / 'web'
+    if fallback.is_dir():
+        return fallback
+
+    return None
+
 
 
 # ── /api/knowledge/parse-menu ─────────────────────────────────────────────────
@@ -336,6 +352,12 @@ async def get_tunnel_url():
         'ready':         ws_url is not None,
     }
  
+
+
+WEB_DIR = _resolve_web_dir()
+if WEB_DIR:
+    app.mount('/', StaticFiles(directory=str(WEB_DIR), html=True), name='dashboard_web')
+
 # ── Entrypoint ─────────────────────────────────────────────────────────────────
 
 if __name__ == '__main__':

--- a/src/dashboard_pkg/launch/dashboard.launch.py
+++ b/src/dashboard_pkg/launch/dashboard.launch.py
@@ -1,6 +1,6 @@
 """
 dashboard.launch.py
-Launches: rosbridge WebSocket + static HTTP server (port 3000) + knowledge API (port 3001)
+Launches: rosbridge WebSocket + unified dashboard server (frontend + API on port 3000)
           + Cloudflare Tunnel (port 3000 and 9090, optional)
 
 Cloudflare Tunnel is enabled by default.
@@ -115,18 +115,12 @@ def generate_launch_description():
             parameters=[{'port': 9090}],
         ),
 
-        # ── Static frontend (port 3000) ───────────────────────────────────
-        ExecuteProcess(
-            cmd=['python3', '-m', 'http.server', '3000'],
-            cwd=web_dir,
-            output='screen',
-        ),
-
-        # ── Knowledge Manager REST API (port 3001) ────────────────────────
+        # ── Unified dashboard server (frontend + API on port 3000) ────────
         ExecuteProcess(
             cmd=['python3', knowledge_api_script,
                  '--repo-root', repo_root,
-                 '--port', '3001'],
+                 '--port', '3000',
+                 '--web-dir', web_dir],
             output='screen',
         ),
 

--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -268,7 +268,6 @@ function getDefaultWsUrl() {
   return `${protocol}://${hostname}:${DEFAULT_WS_PORT}`;
 }
 
-const TUNNEL_API_PORT       = '3001';
 const TUNNEL_POLL_INTERVAL  = 500;   // ms
 const TUNNEL_POLL_MAX = 20;
 
@@ -295,9 +294,7 @@ async function initTunnelWsUrl(setWsUrl) {
   if (!hostname.endsWith('.trycloudflare.com')) return;
   // ────────────────────────────────────────────────────────────────
  
-  // knowledge_api 는 포트 3001 — origin 의 포트만 교체
-  const apiOrigin = window.location.origin.replace(/:\d+$/, '') + ':' + TUNNEL_API_PORT;
-  const apiUrl    = `${apiOrigin}/api/tunnel-url`;
+  const apiUrl = `${window.location.origin}/api/tunnel-url`;
  
   for (let i = 0; i < TUNNEL_POLL_MAX; i++) {
     await new Promise(r => setTimeout(r, TUNNEL_POLL_INTERVAL));


### PR DESCRIPTION
### Motivation
- The previous launch ran the static frontend (`http.server:3000`) and `knowledge_api` (`:3001`) as separate processes which made the dashboard rely on a hardcoded external API port and broke same-origin access for `/api/tunnel-url` when exposed via a single public origin.
- Provide a single external origin that serves both static frontend assets and the `/api/*` endpoints so the browser can fetch `/api/tunnel-url` without cross-origin/port workarounds.

### Description
- Updated `src/dashboard_pkg/launch/dashboard.launch.py` to stop starting `python3 -m http.server :3000` and instead launch the knowledge API process with `--port 3000 --web-dir <web>` so one FastAPI process serves both frontend and API.
- Enhanced `src/dashboard_pkg/dashboard_pkg/knowledge_api.py` to default to port `3000`, accept a `--web-dir` argument, and mount the built frontend using `FastAPI` `StaticFiles` at `/` while keeping existing `/api/*` endpoints (including `/api/tunnel-url`).
- Changed `web/src/core/store.js` to remove the `:3001` coupling and build the tunnel metadata URL from `window.location.origin + '/api/tunnel-url'`, removing `TUNNEL_API_PORT` and hardcoded port logic.
- Preserved existing `/api/tunnel-url` behavior (returns `{ dashboard_url, ws_url, ready }`) and kept `rosbridge` on port `9090` untouched.

### Testing
- Ran `python3 -m py_compile src/dashboard_pkg/launch/dashboard.launch.py src/dashboard_pkg/dashboard_pkg/knowledge_api.py` and it succeeded with no syntax errors.
- Used `fastapi.testclient` against the modified app after writing sample `cloudflared` logs to `/tmp/cloudflared_ws.log` and `/tmp/cloudflared_dashboard.log`; `GET /api/tunnel-url` returned HTTP `200` and a body with `ready: true` and a `ws_url` starting with `wss://` as expected.
- Ran `rg` checks to confirm references to the old `3001` tunnel API port were removed in the launch/store code paths and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d70f1558832cbaf2a70eff5ee14c)