### PR TITLE
Add knowledge_api runtime deps and improve dashboard launch diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ http://localhost:3000
 http://[Robot IP]:3000
 ```
 
+> Note: Port `3000` is now served directly by `knowledge_api.py` (unified frontend + API server).
+> If dashboard launch fails on startup, first verify runtime dependencies are installed (`fastapi`, `uvicorn`, `python-multipart`).
+
 ### Common Launch Options
 
 ```bash

--- a/src/dashboard_pkg/launch/dashboard.launch.py
+++ b/src/dashboard_pkg/launch/dashboard.launch.py
@@ -121,7 +121,9 @@ def generate_launch_description():
                  '--repo-root', repo_root,
                  '--port', '3000',
                  '--web-dir', web_dir],
-            output='screen',
+            output='both',
+            name='knowledge_api_server',
+            emulate_tty=True,
         ),
 
         # ── Cloudflare Tunnel (optional, default: enabled) ────────────────

--- a/src/dashboard_pkg/package.xml
+++ b/src/dashboard_pkg/package.xml
@@ -11,6 +11,9 @@
   
   <exec_depend>rosbridge_server</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>python3-fastapi</exec_depend>
+  <exec_depend>python3-uvicorn</exec_depend>
+  <exec_depend>python3-multipart</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/dashboard_pkg/setup.py
+++ b/src/dashboard_pkg/setup.py
@@ -39,7 +39,7 @@ setup(
         (os.path.join('share', package_name, 'scripts'),
             ['dashboard_pkg/knowledge_api.py']),
     ] + collect_web_data_files(),
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'fastapi', 'uvicorn', 'python-multipart'],
     zip_safe=True,
     maintainer='ofbt',
     maintainer_email='jaewon1627@gmail.com',

--- a/web/README.md
+++ b/web/README.md
@@ -36,8 +36,10 @@ ros2 launch dashboard_pkg dashboard.launch.py
  
 ## Access
 
-- Dashboard: `http://[Robot IP]:3000`
+- Dashboard: `http://[Robot IP]:3000` (`knowledge_api.py` serves port 3000)
 - ROS WebSocket bridge: `ws://[Robot IP]:9090`
+
+If dashboard startup fails, check whether runtime dependencies are installed in the ROS/Python environment: `fastapi`, `uvicorn`, `python-multipart`.
 
 ```text
 # Same machine (robot/local)


### PR DESCRIPTION
### Motivation
- Ensure `knowledge_api.py` has its runtime dependencies declared so the dashboard server can be installed and run reliably. 
- Make it easier to diagnose why the dashboard server on port `3000` fails to start by surfacing stderr/log output from the launched process. 
- Document the fact that port `3000` is served by `knowledge_api.py` and provide a quick dependency check to reduce user troubleshooting time.

### Description
- Added runtime dependency entries to `src/dashboard_pkg/package.xml`: `python3-fastapi`, `python3-uvicorn`, and `python3-multipart` as `exec_depend` entries. 
- Updated `src/dashboard_pkg/setup.py` `install_requires` to include `fastapi`, `uvicorn`, and `python-multipart` in addition to `setuptools`. 
- Hardened the `ExecuteProcess` that runs `knowledge_api.py` (the block matching `ExecuteProcess(cmd=['python3', knowledge_api_script, ...])`) in `src/dashboard_pkg/launch/dashboard.launch.py` by using `output='both'`, adding `name='knowledge_api_server'`, and `emulate_tty=True` to improve stdout/stderr visibility. 
- Clarified dashboard runtime behavior and failure troubleshooting in `README.md` and `web/README.md`, noting that port `3000` is served by `knowledge_api.py` and advising to check for `fastapi`, `uvicorn`, and `python-multipart` if startup fails.

### Testing
- Performed Python syntax checks with `python3 -m py_compile src/dashboard_pkg/launch/dashboard.launch.py src/dashboard_pkg/setup.py`, which completed successfully. 
- Verified the intended source changes via a diff inspection of the modified files (`package.xml`, `setup.py`, `dashboard.launch.py`, `README.md`, `web/README.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6dfecc4fc8326a0e072e37aa4fd10)