### PR TITLE
Clean floating panel headers

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -71,3 +71,9 @@ For broader project context, see the root README: `../README.md`.
 
 
 - System 패널에는 `Topic Publisher`가 포함되며 경로는 `web/src/panels/system/TopicPublisherPanel.jsx`입니다.
+
+### Header ownership rule
+
+- Floating workspace (`FloatingPanel`) and mobile stack (`MobileStack`) own the window title + minimize/close controls. Panels opened there must render content-only roots and must not recreate an internal `Panel` header.
+- Sidebar or fixed tab layouts may still use `web/src/components/Panel.jsx` when they need a local card header/body shell.
+- When moving a panel between layouts, keep header responsibility in exactly one layer and move any padding, overflow, or badge UI into the panel-specific root/CSS.

--- a/web/src/components/Panel.jsx
+++ b/web/src/components/Panel.jsx
@@ -1,6 +1,6 @@
 /**
  * components/Panel.jsx
- * Generic panel wrapper with title bar.
+ * Legacy panel wrapper with title bar for non-floating contexts only.
  * Usage: <Panel title="Event Log" badge={count}> ... </Panel>
  */
 import './Panel.css';

--- a/web/src/panels/perception/BuildingEditorPanel.jsx
+++ b/web/src/panels/perception/BuildingEditorPanel.jsx
@@ -1,17 +1,14 @@
 import { useState, useEffect, useCallback } from 'react';
-import Panel from '../../components/Panel';
 import '../../tabs/KnowledgeTab.css';
 
 const API = '/api/knowledge';
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 function StatusBadge({ status }) {
   const map = {
-    idle:    ['km-badge km-badge-idle',    '—'],
+    idle: ['km-badge km-badge-idle', '—'],
     running: ['km-badge km-badge-running', 'RUNNING'],
-    ok:      ['km-badge km-badge-ok',      'OK'],
-    error:   ['km-badge km-badge-error',   'ERROR'],
+    ok: ['km-badge km-badge-ok', 'OK'],
+    error: ['km-badge km-badge-error', 'ERROR'],
   };
   const [cls, label] = map[status] ?? map.idle;
   return <span className={cls}>{label}</span>;
@@ -25,12 +22,12 @@ const EMPTY_BUILDING = {
 };
 
 function BuildingEditorPanel() {
-  const [buildings, setBuildings]   = useState({});
-  const [selected,  setSelected]    = useState(null);
-  const [draft,     setDraft]       = useState(null);
-  const [saving,    setSaving]      = useState(false);
+  const [buildings, setBuildings] = useState({});
+  const [selected, setSelected] = useState(null);
+  const [draft, setDraft] = useState(null);
+  const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState('idle');
-  const [filter,    setFilter]      = useState('');
+  const [filter, setFilter] = useState('');
 
   const fetchBuildings = useCallback(async () => {
     try {
@@ -48,7 +45,7 @@ function BuildingEditorPanel() {
   }
 
   function updateDraft(field, value) {
-    setDraft(prev => ({ ...prev, [field]: value }));
+    setDraft((prev) => ({ ...prev, [field]: value }));
   }
 
   async function handleSave() {
@@ -64,33 +61,32 @@ function BuildingEditorPanel() {
       if (!res.ok) throw new Error((await res.json()).detail);
       await fetchBuildings();
       setSaveStatus('ok');
-    } catch (e) {
+    } catch {
       setSaveStatus('error');
     }
     setSaving(false);
   }
 
-  const keys = Object.keys(buildings).filter(k =>
-    k.toLowerCase().includes(filter.toLowerCase()) ||
-    (buildings[k].name_ko ?? '').includes(filter) ||
-    (buildings[k].name_en ?? '').toLowerCase().includes(filter.toLowerCase())
+  const keys = Object.keys(buildings).filter((k) =>
+    k.toLowerCase().includes(filter.toLowerCase())
+    || (buildings[k].name_ko ?? '').includes(filter)
+    || (buildings[k].name_en ?? '').toLowerCase().includes(filter.toLowerCase()),
   );
 
   const isEmpty = (b) => !b.name_ko && !b.name_en;
 
   return (
-    <Panel title="Building Editor" className="km-panel km-panel-wide">
+    <div className="km-panel-root km-building-editor-panel km-panel-wide">
       <div className="km-building-layout">
-        {/* Left: key list */}
         <div className="km-building-list">
           <input
             className="km-search"
             placeholder="Search…"
             value={filter}
-            onChange={e => setFilter(e.target.value)}
+            onChange={(e) => setFilter(e.target.value)}
           />
           <div className="km-building-keys">
-            {keys.map(k => (
+            {keys.map((k) => (
               <button
                 key={k}
                 className={`km-building-key ${selected === k ? 'active' : ''} ${isEmpty(buildings[k]) ? 'empty' : ''}`}
@@ -99,14 +95,12 @@ function BuildingEditorPanel() {
                 <span className="km-key-id">{k}</span>
                 {isEmpty(buildings[k])
                   ? <span className="km-key-empty">unfilled</span>
-                  : <span className="km-key-name">{buildings[k].name_ko}</span>
-                }
+                  : <span className="km-key-name">{buildings[k].name_ko}</span>}
               </button>
             ))}
           </div>
         </div>
 
-        {/* Right: editor */}
         <div className="km-building-editor">
           {!draft
             ? <div className="km-empty km-empty-center">Select a building to edit</div>
@@ -114,11 +108,11 @@ function BuildingEditorPanel() {
               <>
                 <div className="km-field-grid">
                   {[
-                    ['Name (KO)',    'name_ko',          'text'],
-                    ['Name (EN)',    'name_en',          'text'],
-                    ['Hours',        'hours',             'text'],
-                    ['URL',          'url',               'text'],
-                    ['Floor',        'floor',             'number'],
+                    ['Name (KO)', 'name_ko', 'text'],
+                    ['Name (EN)', 'name_en', 'text'],
+                    ['Hours', 'hours', 'text'],
+                    ['URL', 'url', 'text'],
+                    ['Floor', 'floor', 'number'],
                   ].map(([label, field, type]) => (
                     <label key={field} className="km-field">
                       <span className="km-field-label">{label}</span>
@@ -126,8 +120,9 @@ function BuildingEditorPanel() {
                         type={type}
                         className="km-input"
                         value={draft[field] ?? ''}
-                        onChange={e => updateDraft(field,
-                          type === 'number' ? Number(e.target.value) : e.target.value
+                        onChange={(e) => updateDraft(
+                          field,
+                          type === 'number' ? Number(e.target.value) : e.target.value,
                         )}
                       />
                     </label>
@@ -137,7 +132,7 @@ function BuildingEditorPanel() {
                     <textarea
                       className="km-input km-textarea"
                       value={draft.description_ko ?? ''}
-                      onChange={e => updateDraft('description_ko', e.target.value)}
+                      onChange={(e) => updateDraft('description_ko', e.target.value)}
                     />
                   </label>
                   <label className="km-field km-field-full">
@@ -145,7 +140,7 @@ function BuildingEditorPanel() {
                     <textarea
                       className="km-input km-textarea"
                       value={draft.description_en ?? ''}
-                      onChange={e => updateDraft('description_en', e.target.value)}
+                      onChange={(e) => updateDraft('description_en', e.target.value)}
                     />
                   </label>
                   <label className="km-field km-field-full">
@@ -154,8 +149,9 @@ function BuildingEditorPanel() {
                       type="text"
                       className="km-input"
                       value={(draft.keywords ?? []).join(', ')}
-                      onChange={e => updateDraft('keywords',
-                        e.target.value.split(',').map(s => s.trim()).filter(Boolean)
+                      onChange={(e) => updateDraft(
+                        'keywords',
+                        e.target.value.split(',').map((s) => s.trim()).filter(Boolean),
                       )}
                     />
                   </label>
@@ -165,8 +161,9 @@ function BuildingEditorPanel() {
                       type="text"
                       className="km-input"
                       value={(draft.facilities ?? []).join(', ')}
-                      onChange={e => updateDraft('facilities',
-                        e.target.value.split(',').map(s => s.trim()).filter(Boolean)
+                      onChange={(e) => updateDraft(
+                        'facilities',
+                        e.target.value.split(',').map((s) => s.trim()).filter(Boolean),
                       )}
                     />
                   </label>
@@ -177,8 +174,9 @@ function BuildingEditorPanel() {
                       step="0.0001"
                       className="km-input"
                       value={draft.coordinates?.[0] ?? 0}
-                      onChange={e => updateDraft('coordinates',
-                        [parseFloat(e.target.value), draft.coordinates?.[1] ?? 0]
+                      onChange={(e) => updateDraft(
+                        'coordinates',
+                        [parseFloat(e.target.value), draft.coordinates?.[1] ?? 0],
                       )}
                     />
                   </label>
@@ -189,8 +187,9 @@ function BuildingEditorPanel() {
                       step="0.0001"
                       className="km-input"
                       value={draft.coordinates?.[1] ?? 0}
-                      onChange={e => updateDraft('coordinates',
-                        [draft.coordinates?.[0] ?? 0, parseFloat(e.target.value)]
+                      onChange={(e) => updateDraft(
+                        'coordinates',
+                        [draft.coordinates?.[0] ?? 0, parseFloat(e.target.value)],
                       )}
                     />
                   </label>
@@ -213,11 +212,10 @@ function BuildingEditorPanel() {
                   <StatusBadge status={saveStatus} />
                 </div>
               </>
-            )
-          }
+            )}
         </div>
       </div>
-    </Panel>
+    </div>
   );
 }
 

--- a/web/src/panels/perception/DocumentBrowserPanel.jsx
+++ b/web/src/panels/perception/DocumentBrowserPanel.jsx
@@ -1,13 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
-import Panel from '../../components/Panel';
 import '../../tabs/KnowledgeTab.css';
 
 const API = '/api/knowledge';
 
 function DocumentBrowserPanel() {
-  const [docs,    setDocs]    = useState([]);
+  const [docs, setDocs] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [filter,  setFilter]  = useState('');
+  const [filter, setFilter] = useState('');
 
   const fetchDocs = useCallback(async () => {
     setLoading(true);
@@ -18,22 +17,39 @@ function DocumentBrowserPanel() {
     setLoading(false);
   }, []);
 
-  useEffect(() => { fetchDocs(); }, [fetchDocs]);
+  useEffect(() => {
+    let cancelled = false;
 
-  const filtered = docs.filter(d =>
-    d.source.toLowerCase().includes(filter.toLowerCase())
+    async function loadDocs() {
+      setLoading(true);
+      try {
+        const res = await fetch(`${API}/documents`);
+        if (!cancelled && res.ok) setDocs(await res.json());
+      } catch { /* ignore */ }
+      if (!cancelled) setLoading(false);
+    }
+
+    loadDocs();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = docs.filter((d) =>
+    d.source.toLowerCase().includes(filter.toLowerCase()),
   );
 
   return (
-    <Panel title="Indexed Documents" badge={docs.length} className="km-panel">
+    <div className="km-panel-root km-document-browser-panel">
       <div className="km-section">
-        <div className="km-toolbar">
+        <div className="km-toolbar km-toolbar-with-badge">
           <input
             className="km-search"
             placeholder="Filter by filename…"
             value={filter}
-            onChange={e => setFilter(e.target.value)}
+            onChange={(e) => setFilter(e.target.value)}
           />
+          <span className="km-panel-badge">{docs.length}</span>
           <button className="km-btn" onClick={fetchDocs} disabled={loading}>
             {loading ? '…' : '↻'}
           </button>
@@ -55,7 +71,7 @@ function DocumentBrowserPanel() {
           ))}
         </div>
       </div>
-    </Panel>
+    </div>
   );
 }
 

--- a/web/src/panels/perception/IndexBuilderPanel.jsx
+++ b/web/src/panels/perception/IndexBuilderPanel.jsx
@@ -1,17 +1,14 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import Panel from '../../components/Panel';
 import '../../tabs/KnowledgeTab.css';
 
 const API = '/api/knowledge';
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 function StatusBadge({ status }) {
   const map = {
-    idle:    ['km-badge km-badge-idle',    '—'],
+    idle: ['km-badge km-badge-idle', '—'],
     running: ['km-badge km-badge-running', 'RUNNING'],
-    ok:      ['km-badge km-badge-ok',      'OK'],
-    error:   ['km-badge km-badge-error',   'ERROR'],
+    ok: ['km-badge km-badge-ok', 'OK'],
+    error: ['km-badge km-badge-error', 'ERROR'],
   };
   const [cls, label] = map[status] ?? map.idle;
   return <span className={cls}>{label}</span>;
@@ -26,21 +23,20 @@ function LogPane({ lines }) {
     <div className="km-log" ref={ref}>
       {lines.length === 0
         ? <span className="km-log-empty">No output yet.</span>
-        : lines.map((l, i) => <div key={i} className="km-log-line">{l}</div>)
-      }
+        : lines.map((l, i) => <div key={i} className="km-log-line">{l}</div>)}
     </div>
   );
 }
 
 function IndexBuilderPanel() {
-  const [status,    setStatus]    = useState('idle');
-  const [log,       setLog]       = useState([]);
+  const [status, setStatus] = useState('idle');
+  const [log, setLog] = useState([]);
   const [incremental, setIncremental] = useState(true);
   const [indexInfo, setIndexInfo] = useState(null);
   const pollRef = useRef(null);
 
   function appendLog(msg) {
-    setLog(prev => [...prev, `${new Date().toLocaleTimeString()}  ${msg}`]);
+    setLog((prev) => [...prev, `${new Date().toLocaleTimeString()}  ${msg}`]);
   }
 
   const fetchIndexInfo = useCallback(async () => {
@@ -68,14 +64,13 @@ function IndexBuilderPanel() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.detail ?? res.statusText);
 
-      // Poll job status
       const jobId = data.job_id;
       appendLog(`Job started: ${jobId}`);
 
       pollRef.current = setInterval(async () => {
         const r = await fetch(`${API}/build-index/status/${jobId}`);
         const d = await r.json();
-        d.new_lines?.forEach(l => appendLog(l));
+        d.new_lines?.forEach((l) => appendLog(l));
         if (d.status === 'done') {
           clearInterval(pollRef.current);
           appendLog(`[OK] Done — ${d.total_chunks} chunks indexed.`);
@@ -96,7 +91,7 @@ function IndexBuilderPanel() {
   useEffect(() => () => clearInterval(pollRef.current), []);
 
   return (
-    <Panel title="Index Builder" className="km-panel">
+    <div className="km-panel-root km-index-builder-panel">
       <div className="km-section">
         <p className="km-hint">
           Embeds <code>data/campus/processed/**/*.txt</code> with
@@ -121,7 +116,7 @@ function IndexBuilderPanel() {
           <input
             type="checkbox"
             checked={incremental}
-            onChange={e => setIncremental(e.target.checked)}
+            onChange={(e) => setIncremental(e.target.checked)}
           />
           <span>Incremental (skip unchanged files)</span>
         </label>
@@ -139,7 +134,7 @@ function IndexBuilderPanel() {
 
         <LogPane lines={log} />
       </div>
-    </Panel>
+    </div>
   );
 }
 

--- a/web/src/panels/perception/MenuParserPanel.jsx
+++ b/web/src/panels/perception/MenuParserPanel.jsx
@@ -1,18 +1,15 @@
 import { useState, useEffect, useRef } from 'react';
 import { X } from 'lucide-react';
-import Panel from '../../components/Panel';
 import '../../tabs/KnowledgeTab.css';
 
 const API = '/api/knowledge';
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 function StatusBadge({ status }) {
   const map = {
-    idle:    ['km-badge km-badge-idle',    '—'],
+    idle: ['km-badge km-badge-idle', '—'],
     running: ['km-badge km-badge-running', 'RUNNING'],
-    ok:      ['km-badge km-badge-ok',      'OK'],
-    error:   ['km-badge km-badge-error',   'ERROR'],
+    ok: ['km-badge km-badge-ok', 'OK'],
+    error: ['km-badge km-badge-error', 'ERROR'],
   };
   const [cls, label] = map[status] ?? map.idle;
   return <span className={cls}>{label}</span>;
@@ -27,20 +24,19 @@ function LogPane({ lines }) {
     <div className="km-log" ref={ref}>
       {lines.length === 0
         ? <span className="km-log-empty">No output yet.</span>
-        : lines.map((l, i) => <div key={i} className="km-log-line">{l}</div>)
-      }
+        : lines.map((l, i) => <div key={i} className="km-log-line">{l}</div>)}
     </div>
   );
 }
 
 function MenuParserPanel() {
-  const [files,   setFiles]   = useState([]);
-  const [status,  setStatus]  = useState('idle');
-  const [log,     setLog]     = useState([]);
+  const [files, setFiles] = useState([]);
+  const [status, setStatus] = useState('idle');
+  const [log, setLog] = useState([]);
   const inputRef = useRef(null);
 
   function appendLog(msg) {
-    setLog(prev => [...prev, `${new Date().toLocaleTimeString()}  ${msg}`]);
+    setLog((prev) => [...prev, `${new Date().toLocaleTimeString()}  ${msg}`]);
   }
 
   async function handleUpload() {
@@ -50,14 +46,14 @@ function MenuParserPanel() {
     appendLog(`Uploading ${files.length} file(s)…`);
 
     const fd = new FormData();
-    files.forEach(f => fd.append('files', f));
+    files.forEach((f) => fd.append('files', f));
 
     try {
       const res = await fetch(`${API}/parse-menu`, { method: 'POST', body: fd });
       const data = await res.json();
       if (!res.ok) throw new Error(data.detail ?? res.statusText);
 
-      data.results.forEach(r => {
+      data.results.forEach((r) => {
         if (r.ok) {
           appendLog(`[OK] ${r.filename}  →  ${r.out_json}`);
           appendLog(`  └ ${r.out_txt}`);
@@ -65,7 +61,7 @@ function MenuParserPanel() {
           appendLog(`[ERR] ${r.filename}  —  ${r.error}`);
         }
       });
-      setStatus(data.results.every(r => r.ok) ? 'ok' : 'error');
+      setStatus(data.results.every((r) => r.ok) ? 'ok' : 'error');
     } catch (e) {
       appendLog(`ERROR: ${e.message}`);
       setStatus('error');
@@ -75,27 +71,26 @@ function MenuParserPanel() {
   function handleDrop(e) {
     e.preventDefault();
     const dropped = [...e.dataTransfer.files].filter(
-      f => f.name.endsWith('.xlsx') || f.name.endsWith('.pdf')
+      (f) => f.name.endsWith('.xlsx') || f.name.endsWith('.pdf'),
     );
-    setFiles(prev => [...prev, ...dropped]);
+    setFiles((prev) => [...prev, ...dropped]);
   }
 
   function removeFile(idx) {
-    setFiles(prev => prev.filter((_, i) => i !== idx));
+    setFiles((prev) => prev.filter((_, i) => i !== idx));
   }
 
   return (
-    <Panel title="Menu Parser" className="km-panel">
+    <div className="km-panel-root km-menu-parser-panel">
       <div className="km-section">
         <p className="km-hint">
           Upload weekly menu files (<code>.xlsx</code> / <code>.pdf</code>).
           Parsed output is saved to <code>data/campus/processed/cafeteria/</code>.
         </p>
 
-        {/* Drop zone */}
         <div
           className={`km-dropzone ${files.length > 0 ? 'has-files' : ''}`}
-          onDragOver={e => e.preventDefault()}
+          onDragOver={(e) => e.preventDefault()}
           onDrop={handleDrop}
           onClick={() => inputRef.current?.click()}
         >
@@ -105,12 +100,12 @@ function MenuParserPanel() {
             accept=".xlsx,.pdf"
             multiple
             style={{ display: 'none' }}
-            onChange={e => setFiles(prev => [...prev, ...[...e.target.files]])}
+            onChange={(e) => setFiles((prev) => [...prev, ...[...e.target.files]])}
           />
           {files.length === 0
             ? <span className="km-dropzone-hint">Drop .xlsx / .pdf here or click to browse</span>
             : (
-              <ul className="km-file-list" onClick={e => e.stopPropagation()}>
+              <ul className="km-file-list" onClick={(e) => e.stopPropagation()}>
                 {files.map((f, i) => (
                   <li key={i} className="km-file-item">
                     <span className="km-file-name">{f.name}</span>
@@ -121,8 +116,7 @@ function MenuParserPanel() {
                   </li>
                 ))}
               </ul>
-            )
-          }
+            )}
         </div>
 
         <div className="km-actions">
@@ -143,7 +137,7 @@ function MenuParserPanel() {
 
         <LogPane lines={log} />
       </div>
-    </Panel>
+    </div>
   );
 }
 

--- a/web/src/panels/system/ConnectionInfoPanel.jsx
+++ b/web/src/panels/system/ConnectionInfoPanel.jsx
@@ -1,4 +1,3 @@
-import Panel from '../../components/Panel';
 import { useStore } from '../../core/store';
 import { parseWsUrl } from '../../core/url';
 import '../../tabs/SystemTab.css';
@@ -11,7 +10,7 @@ function ConnectionInfoPanel() {
   const parsedWsUrl = parseWsUrl(wsUrl);
 
   return (
-    <Panel title="Connection Info">
+    <div className="sys-panel-root sys-panel-connection">
       <div className="sys-info">
         <div className="sys-info-row">
           <span>Status</span>
@@ -43,7 +42,7 @@ function ConnectionInfoPanel() {
           </div>
         )}
       </div>
-    </Panel>
+    </div>
   );
 }
 

--- a/web/src/panels/system/MetricsPanel.jsx
+++ b/web/src/panels/system/MetricsPanel.jsx
@@ -1,4 +1,3 @@
-import Panel from '../../components/Panel';
 import { useStore } from '../../core/store';
 import { fmt, isWarn, pct, primaryClass, valueClass } from './shared/formatters';
 import '../../tabs/SystemTab.css';
@@ -38,7 +37,7 @@ function MetricsPanel({ className = 'sys-panel-metrics' }) {
   const disk = systemMetrics?.disk;
 
   return (
-    <Panel title="System Metrics" className={className}>
+    <div className={`sys-panel-root sys-panel-metrics-root ${className}`.trim()}>
       <div className="sys-metrics-body">
         <MetricCard
           title="CPU"
@@ -82,7 +81,7 @@ function MetricsPanel({ className = 'sys-panel-metrics' }) {
           ]}
         />
       </div>
-    </Panel>
+    </div>
   );
 }
 

--- a/web/src/panels/system/TopicDiagnosticsPanel.jsx
+++ b/web/src/panels/system/TopicDiagnosticsPanel.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
-import Panel from '../../components/Panel';
 import { TOPIC_META, useStore } from '../../core/store';
 import { fmt, hzClass } from './shared/formatters';
 import '../../tabs/SystemTab.css';
@@ -62,7 +61,7 @@ function TopicDiagnosticsPanel({ className = 'sys-panel-diag' }) {
   }, [allRows, search, sortKey, sortDir]);
 
   return (
-    <Panel title="Topic Diagnostics" className={className}>
+    <div className={`sys-panel-root sys-panel-diag-root ${className}`.trim()}>
       <div className="sys-topic-diag">
         <div className="sys-diag-toolbar">
           <input
@@ -136,7 +135,7 @@ function TopicDiagnosticsPanel({ className = 'sys-panel-diag' }) {
           </table>
         </div>
       </div>
-    </Panel>
+    </div>
   );
 }
 

--- a/web/src/panels/system/TopicPublisherPanel.css
+++ b/web/src/panels/system/TopicPublisherPanel.css
@@ -128,6 +128,13 @@
   background: var(--red-dim, rgba(214,107,102,0.12));
 }
 
+.tp-panel-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
 /* ── Panel body ──────────────────────────────────────────────────────────── */
 
 .tp-body {
@@ -136,7 +143,8 @@
   gap: 8px;
   padding: 10px 12px 12px;
   overflow-y: auto;
-  max-height: calc(100vh - 120px);
+  min-height: 0;
+  height: 100%;
 }
 
 .tp-row {

--- a/web/src/panels/system/TopicPublisherPanel.jsx
+++ b/web/src/panels/system/TopicPublisherPanel.jsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Panel from '../../components/Panel';
 import { LOG_TAGS, useStore } from '../../core/store';
 import { publishROS } from '../../core/ros';
 import './TopicPublisherPanel.css';
@@ -135,8 +134,8 @@ export default function TopicPublisherPanel() {
   useEffect(() => () => stopPeriodic(), [stopPeriodic]);
 
   return (
-    <Panel title="Topic Publisher">
-      <div className="tp-body" style={{ padding: 0 }}>
+    <div className="tp-panel-root">
+      <div className="tp-body">
         <div className="tp-row">
           <label htmlFor="tp-topic">Topic</label>
           <select id="tp-topic" value={topic} onChange={(e) => setTopic(e.target.value)}>
@@ -198,6 +197,6 @@ export default function TopicPublisherPanel() {
           </div>
         )}
       </div>
-    </Panel>
+    </div>
   );
 }

--- a/web/src/tabs/KnowledgeTab.css
+++ b/web/src/tabs/KnowledgeTab.css
@@ -24,13 +24,21 @@
 .km-col-left  { /* Menu Parser + Index Builder */ }
 .km-col-right { /* Doc Browser + Building Editor */ flex: 1; }
 
-.km-panel {
+.km-panel,
+.km-panel-root {
   flex: 1;
   min-height: 0;
 }
 
 .km-panel-wide {
   flex: 2;
+}
+
+.km-panel-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
 }
 
 /* ── Section wrapper ──────────────────────────────────────────────────────── */
@@ -287,6 +295,24 @@
   display: flex;
   gap: 6px;
   align-items: center;
+}
+
+.km-toolbar-with-badge {
+  align-items: stretch;
+}
+
+.km-panel-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  padding: 0 8px;
+  font-size: 10px;
+  color: var(--text-2);
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
 }
 
 .km-search {

--- a/web/src/tabs/SystemTab.css
+++ b/web/src/tabs/SystemTab.css
@@ -32,6 +32,17 @@
   flex-shrink: 0;
 }
 
+.sys-panel-root {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+.sys-panel-connection {
+  overflow: auto;
+}
+
 /* ── Topic Diagnostics ───────────────────────────────────────────────────── */
 
 .sys-topic-diag {


### PR DESCRIPTION
### Motivation

- Floating windows already render a title bar via `FloatingPanel`, so panels opened in the floating workspace must not duplicate headers; header ownership should live in one place to avoid overlapping controls and inconsistent sizing.
- Several system and perception panels used the generic `Panel` wrapper which reintroduced header/body layout that belongs to sidebar/tab contexts.

### Description

- Removed `Panel` import and wrapper from system panels (`ConnectionInfoPanel`, `TopicDiagnosticsPanel`, `MetricsPanel`, `TopicPublisherPanel`) and replaced the top-level JSX with meaningful content roots (e.g. `sys-panel-root`, `sys-panel-diag-root`, `sys-panel-metrics-root`, `tp-panel-root`).
- Did the same for perception panels (`MenuParserPanel`, `IndexBuilderPanel`, `DocumentBrowserPanel`, `BuildingEditorPanel`), adding panel-specific root classes such as `km-panel-root`, `km-menu-parser-panel`, `km-index-builder-panel`, `km-document-browser-panel`, `km-building-editor-panel` and moving badge/UI into panel-local markup where needed.
- Moved body sizing/overflow/padding and the topic-publisher container rules into panel CSS (`web/src/tabs/SystemTab.css`, `web/src/tabs/KnowledgeTab.css`, `web/src/panels/system/TopicPublisherPanel.css`) and added `*.sys-panel-root` / `*.km-panel-root` / `.tp-panel-root` containers to preserve scrolling and layout behavior.
- Marked `web/src/components/Panel.jsx` as a legacy wrapper (updated header comment) and added a `Header ownership rule` to `web/README.md` documenting that `FloatingPanel`/`MobileStack` own title controls while sidebar/tab contexts may still use `Panel.jsx`.
- Small behavioral/quality tweaks: adjusted initial document loading in `DocumentBrowserPanel` to avoid a `set-state-in-effect` pattern and made minor code formatting/arrow-function fixes in the edited panel files.

### Testing

- Ran a production build: `cd web && npm run build` and the frontend build completed successfully.
- Ran repository lint: `cd web && npm run lint` which failed due to pre-existing repository-wide ESLint issues outside the touched files (these are unrelated to the panel changes and were reported by the linter). 
- Ran focused ESLint against the modified panel files with `npx eslint ...` for the touched panel files and `web/src/components/Panel.jsx`, which completed for the targeted files; the changes do not introduce new lint issues in the edited files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba79ea9da08326b255ef9b6a49f864)