### PR TITLE
SPA fallback: 404 missing static assets, index.html only for extensionless routes

### DIFF
--- a/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -383,14 +383,30 @@ WEB_DIR = _resolve_web_dir()
 if WEB_DIR:
     from fastapi.responses import FileResponse as _FileResponse
 
+    _STATIC_FILE_EXTENSIONS = {
+        '.js', '.mjs', '.css', '.map', '.png', '.jpg', '.svg', '.ico', '.woff', '.woff2',
+    }
+
     @app.get('/{full_path:path}', include_in_schema=False)
     async def serve_spa(full_path: str):
         # 실제 파일이 있으면 그대로 반환 (JS, CSS, 이미지 등)
         target = WEB_DIR / full_path
         if target.is_file():
             return _FileResponse(str(target))
-        # 없으면 SPA fallback
-        return _FileResponse(str(WEB_DIR / 'index.html'))
+
+        requested_path = Path(full_path)
+        is_asset_request = (
+            'assets' in requested_path.parts
+            or requested_path.suffix.lower() in _STATIC_FILE_EXTENSIONS
+        )
+        if is_asset_request:
+            raise HTTPException(404, 'Not Found')
+
+        # 파일 확장자가 없는 SPA route만 index.html fallback 처리
+        if not requested_path.suffix:
+            return _FileResponse(str(WEB_DIR / 'index.html'))
+
+        raise HTTPException(404, 'Not Found')
 
 # ── /api/webhook + /api/deploy/* ──────────────────────────────────────────────
 # GitHub Webhook receiver + async deploy pipeline


### PR DESCRIPTION
### Motivation
- Prevent browsers and CDNs from caching HTML under asset URLs by avoiding an `index.html` fallback for missing static files.
- Keep existing behavior of serving real files from the dashboard web directory when they exist.
- Only fall back to `index.html` for SPA application pages (extensionless routes) so page navigation continues to work.

### Description
- Added a `_STATIC_FILE_EXTENSIONS` set containing known static extensions like `.js`, `.mjs`, `.css`, `.map`, `.png`, `.jpg`, `.svg`, `.ico`, `.woff`, and `.woff2`.
- Updated the `serve_spa` handler to return the requested file when `target.is_file()` is true, and to treat requests under an `assets/` path or with a static-file extension as asset requests.
- For asset requests where the file is missing, the handler now raises `HTTPException(404, 'Not Found')` instead of returning `index.html`.
- The handler only falls back to `index.html` when the requested path has no file extension (`requested_path.suffix` is empty); all other missing file-like paths return a 404.

### Testing
- Ran `python -m py_compile src/dashboard_pkg/dashboard_pkg/knowledge_api.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb41bff1b08326a94ae98f0994c2ad)