### PR TITLE
Harden dashboard static deploy publishing

### DIFF
--- a/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -21,6 +21,8 @@ import argparse
 import asyncio
 import json
 import os
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -83,6 +85,10 @@ def _resolve_web_dir() -> Path | None:
         candidate = Path(args.web_dir).expanduser().resolve()
         if candidate.is_dir():
             return candidate
+
+    published = Path(__file__).resolve().parents[2] / 'web_current'
+    if published.is_dir():
+        return published
 
     fallback = Path(__file__).resolve().parents[2] / 'web'
     if fallback.is_dir():
@@ -439,6 +445,8 @@ if WEB_DIR:
 # ── /api/webhook + /api/deploy/* ──────────────────────────────────────────────
 # GitHub Webhook receiver + async deploy pipeline
 # Pipeline: git pull → npm run build (if web changed) → colcon build
+#        → validate installed static tree → publish web_current symlink
+# Only purge CDN/browser caches after the publish step completes.
 #
 # Env vars:
 #   DORI_WEBHOOK_SECRET  : GitHub webhook secret (HMAC-SHA256)
@@ -519,6 +527,107 @@ def _web_dir() -> Path | None:
     """Return the web/ directory path if it exists."""
     candidate = REPO_ROOT / 'web'
     return candidate if candidate.is_dir() else None
+
+
+def _installed_dashboard_share_dir() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _built_web_dir() -> Path:
+    return _installed_dashboard_share_dir() / 'web'
+
+
+def _published_web_dir() -> Path:
+    return _installed_dashboard_share_dir() / 'web_current'
+
+
+def _web_release_root() -> Path:
+    return _installed_dashboard_share_dir() / 'web_releases'
+
+
+def _extract_index_asset_paths(index_path: Path) -> list[str]:
+    text = index_path.read_text(encoding='utf-8')
+    matches = re.findall(r'''(?:src|href)=["']([^"']+)["']''', text)
+    return [
+        match.lstrip('/')
+        for match in matches
+        if match and not match.startswith(('http://', 'https://', '//'))
+    ]
+
+
+def _validate_static_tree(web_dir: Path) -> list[str]:
+    missing: list[str] = []
+    index_path = web_dir / 'index.html'
+    if not index_path.is_file():
+        return ['index.html']
+
+    for asset_path in _extract_index_asset_paths(index_path):
+        if asset_path.startswith('api/'):
+            continue
+        if not (web_dir / asset_path).is_file():
+            missing.append(asset_path)
+
+    return missing
+
+
+def _publish_built_web_tree() -> tuple[bool, str]:
+    """
+    Publish a fully built static tree via an atomic symlink swap.
+
+    Flow:
+      1) Validate install/share/dashboard_pkg/web is complete.
+      2) Copy it into a new versioned release directory.
+      3) Atomically replace web_current -> web_releases/<release>.
+
+    Operators should purge CDN/browser caches only after this completes.
+    """
+    built_web_dir = _built_web_dir()
+    missing = _validate_static_tree(built_web_dir)
+    if missing:
+        preview = ', '.join(missing[:5])
+        if len(missing) > 5:
+            preview += f', ... (+{len(missing) - 5} more)'
+        return False, (
+            'Installed static tree is incomplete; refusing to publish '
+            f'{built_web_dir}. Missing: {preview}'
+        )
+
+    release_root = _web_release_root()
+    release_root.mkdir(parents=True, exist_ok=True)
+
+    release_name = datetime.utcnow().strftime('%Y%m%dT%H%M%S') + f'-{uuid.uuid4().hex[:8]}'
+    release_dir = release_root / release_name
+    tmp_release_dir = release_root / f'.{release_name}.tmp'
+
+    if tmp_release_dir.exists():
+        shutil.rmtree(tmp_release_dir)
+    shutil.copytree(built_web_dir, tmp_release_dir)
+
+    copied_missing = _validate_static_tree(tmp_release_dir)
+    if copied_missing:
+        shutil.rmtree(tmp_release_dir, ignore_errors=True)
+        preview = ', '.join(copied_missing[:5])
+        if len(copied_missing) > 5:
+            preview += f', ... (+{len(copied_missing) - 5} more)'
+        return False, (
+            'Staged static tree is incomplete after copy; refusing to publish. '
+            f'Missing: {preview}'
+        )
+
+    tmp_release_dir.rename(release_dir)
+
+    published_link = _published_web_dir()
+    tmp_link = published_link.with_name(published_link.name + '.tmp')
+    if tmp_link.exists() or tmp_link.is_symlink():
+        tmp_link.unlink()
+    tmp_link.symlink_to(release_dir, target_is_directory=True)
+    os.replace(tmp_link, published_link)
+
+    return True, (
+        'Published dashboard static tree via atomic symlink swap. '
+        f'Active tree: {published_link} -> {release_dir}. '
+        'Cache purge/window for public exposure must happen after this step.'
+    )
 
 
 def _changed_paths(pull_stdout: str) -> list[str]:
@@ -611,7 +720,7 @@ def _deploy_pipeline():
 
     if packages_to_build:
         _deploy_job['steps'].append({
-            'name': 'colcon build target packages',
+            'step': 'select packages',
             'status': 'done',
             'log': 'Packages selected: ' + ', '.join(packages_to_build),
         })
@@ -628,6 +737,31 @@ def _deploy_pipeline():
             _deploy_job.update({'status': 'error', 'error': 'colcon build failed',
                                 'finished_at': datetime.datetime.now().isoformat()})
             return
+
+    # ── Step 4: publish dashboard static tree only after install completes ───
+    if web_changed:
+        step = {
+            'step': 'publish dashboard static tree',
+            'status': 'running',
+            'log': (
+                'Validating install/share/dashboard_pkg/web, copying into a new '
+                'versioned release directory, and switching web_current only '
+                'after the full asset set is present. Purge caches only after '
+                'this step reports done.'
+            ),
+        }
+        _deploy_job['steps'].append(step)
+        ok, publish_log = _publish_built_web_tree()
+        step['log'] += '\n' + publish_log
+        if not ok:
+            step['status'] = 'error'
+            _deploy_job.update({
+                'status': 'error',
+                'error': 'dashboard static publish failed',
+                'finished_at': datetime.datetime.now().isoformat(),
+            })
+            return
+        step['status'] = 'done'
 
     _deploy_job.update({'status': 'done',
                         'finished_at': datetime.datetime.now().isoformat()})

--- a/src/dashboard_pkg/launch/dashboard.launch.py
+++ b/src/dashboard_pkg/launch/dashboard.launch.py
@@ -88,7 +88,9 @@ def _make_tunnel_actions(context, *args, **kwargs):
 def _make_api_server_action(context, *args, **kwargs):
     """OpaqueFunction: knowledge_api 를 환경변수와 함께 실행."""
     pkg_dir   = get_package_share_directory('dashboard_pkg')
-    web_dir   = os.path.join(pkg_dir, 'web')
+    web_dir   = os.path.join(pkg_dir, 'web_current')
+    if not os.path.isdir(web_dir):
+        web_dir = os.path.join(pkg_dir, 'web')
     repo_root = os.path.abspath(os.path.join(pkg_dir, '..', '..', '..', '..'))
     knowledge_api_script = os.path.join(pkg_dir, 'scripts', 'knowledge_api.py')
 
@@ -117,12 +119,15 @@ def _make_api_server_action(context, *args, **kwargs):
 
 def generate_launch_description():
     pkg_dir = get_package_share_directory('dashboard_pkg')
-    web_dir = os.path.join(pkg_dir, 'web')
+    web_dir = os.path.join(pkg_dir, 'web_current')
+    if not os.path.isdir(web_dir):
+        web_dir = os.path.join(pkg_dir, 'web')
 
     if not os.path.isdir(web_dir):
         raise FileNotFoundError(
             'dashboard_pkg web assets not found. Expected directory: '
-            f"'{web_dir}'. Build the frontend (web/dist) before installing and launching dashboard_pkg."
+            f"'{web_dir}'. Build the frontend (web/dist), install dashboard_pkg, and publish the "
+            'completed static tree before launching the dashboard.'
         )
 
     repo_root = os.path.abspath(os.path.join(pkg_dir, '..', '..', '..', '..'))

--- a/src/dashboard_pkg/setup.py
+++ b/src/dashboard_pkg/setup.py
@@ -9,7 +9,13 @@ repo_root = setup_dir.parents[1]
 
 
 def collect_web_data_files():
-    """Collect web build artifacts from the repository-level web/dist directory."""
+    """
+    Collect web build artifacts from the repository-level web/dist directory.
+
+    These files are installed into share/dashboard_pkg/web as a complete static
+    tree. The deploy pipeline validates that installed tree and only then
+    publishes it via share/dashboard_pkg/web_current for public traffic.
+    """
     web_dist_dir = repo_root / 'web' / 'dist'
     if not web_dist_dir.exists():
         return []


### PR DESCRIPTION
### Motivation
- Prevent the public server from serving a new `index.html` before the matching `assets/*` are present to avoid broken pages during deploys.
- Prefer publishing a complete static tree into a new location and switching the served directory atomically, or at minimum ensure the installed `share/dashboard_pkg/web` tree is validated before cache purge or public exposure.

### Description
- Add validation and publishing helpers to `src/dashboard_pkg/dashboard_pkg/knowledge_api.py` (`_validate_static_tree`, `_extract_index_asset_paths`, `_publish_built_web_tree`, and helpers for release paths) that copy a built `share/dashboard_pkg/web` into a versioned release and atomically swap `web_current` to the new release.
- Extend the webhook/deploy pipeline in `knowledge_api.py` to run a publish step after `colcon build` and to record the publish step in the deploy job steps, with explicit guidance that caches should be purged only after publish completes.
- Make the runtime launch flow prefer the published tree by updating `src/dashboard_pkg/launch/dashboard.launch.py` to use `share/dashboard_pkg/web_current` (falling back to `share/dashboard_pkg/web` if needed) and update the error message to instruct operators to publish the completed static tree before launching.
- Document the installed/static relationship in `src/dashboard_pkg/setup.py` so operators know that files are installed into `share/dashboard_pkg/web` and the deploy publishes into `web_current` for public traffic.

### Testing
- `python -m py_compile src/dashboard_pkg/setup.py src/dashboard_pkg/launch/dashboard.launch.py src/dashboard_pkg/dashboard_pkg/knowledge_api.py` completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb4cfca0bc83268de002ed7cc91b55)