### PR TITLE
refactor: migrate gesture and facial nodes to MediaPipe Tasks API

### DIFF
--- a/src/hri_pkg/hri_pkg/facial_expression_node.py
+++ b/src/hri_pkg/hri_pkg/facial_expression_node.py
@@ -32,6 +32,12 @@ from std_msgs.msg import Bool, String
 
 try:
     import mediapipe as mp
+    from mediapipe.tasks.python import BaseOptions
+    from mediapipe.tasks.python.vision import (
+        FaceLandmarker,
+        FaceLandmarkerOptions,
+        RunningMode,
+    )
     MP_AVAILABLE = True
 except ImportError:
     MP_AVAILABLE = False
@@ -74,6 +80,7 @@ class FacialExpressionNode(Node):
         super().__init__('facial_expression_node')
 
         # Parameters
+        self.declare_parameter('face_model_path', '')
         self.declare_parameter('min_detection_confidence', 0.5)
         self.declare_parameter('min_tracking_confidence', 0.5)
         self.declare_parameter('visualize', True)
@@ -100,17 +107,28 @@ class FacialExpressionNode(Node):
             self.get_logger().error('mediapipe not installed: pip install mediapipe')
             return
 
-        # MediaPipe Face Mesh initialization
-        self.mp_face_mesh = mp.solutions.face_mesh
+        # MediaPipe Face Landmarker initialization (Tasks API)
         self.mp_drawing   = mp.solutions.drawing_utils
         self.mp_styles    = mp.solutions.drawing_styles
-        self.face_mesh = self.mp_face_mesh.FaceMesh(
-            static_image_mode=False,
-            max_num_faces=1,
-            refine_landmarks=False,
-            min_detection_confidence=det_conf,
+        self.mp_face_mesh_connections = mp.solutions.face_mesh
+        self.face_mesh = None
+        face_model_path = self.get_parameter('face_model_path').value
+        if not face_model_path:
+            self.get_logger().error(
+                'face_model_path is empty. Set a valid MediaPipe .task model path.')
+            return
+
+        face_options = FaceLandmarkerOptions(
+            base_options=BaseOptions(model_asset_path=face_model_path),
+            running_mode=RunningMode.VIDEO,
+            num_faces=1,
+            min_face_detection_confidence=det_conf,
+            min_face_presence_confidence=det_conf,
             min_tracking_confidence=trk_conf,
+            output_face_blendshapes=False,
+            output_facial_transformation_matrixes=False,
         )
+        self.face_mesh = FaceLandmarker.create_from_options(face_options)
 
         # State
         self.is_active = not self.active_on_trigger
@@ -160,16 +178,20 @@ class FacialExpressionNode(Node):
 
         h, w = cv_image.shape[:2]
         rgb = cv2.cvtColor(cv_image, cv2.COLOR_BGR2RGB)
-        results = self.face_mesh.process(rgb)
+        mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
+        timestamp_ms = int(msg.header.stamp.sec * 1000 + msg.header.stamp.nanosec / 1_000_000)
+        if timestamp_ms <= 0:
+            timestamp_ms = int(time.monotonic() * 1000)
+        results = self.face_mesh.detect_for_video(mp_image, timestamp_ms)
 
-        if not results.multi_face_landmarks:
+        if not results.face_landmarks:
             self._expr_history.append(Expression.NEUTRAL)
             self._publish_expression(Expression.NEUTRAL, {}, msg)
             if self.visualize:
                 self._publish_annotated(cv_image, None, Expression.NEUTRAL, {}, msg)
             return
 
-        face_lm = results.multi_face_landmarks[0].landmark
+        face_lm = results.face_landmarks[0]
         metrics = self._extract_metrics(face_lm, w, h)
         expression = self._classify(metrics)
 
@@ -192,7 +214,7 @@ class FacialExpressionNode(Node):
 
         if self.visualize:
             self._publish_annotated(
-                cv_image, results.multi_face_landmarks[0], confirmed, metrics, msg)
+                cv_image, results.face_landmarks[0], confirmed, metrics, msg)
 
     def _extract_metrics(self, lm, w: int, h: int) -> dict:
         nose_y = lm[NOSE_TIP].y
@@ -301,7 +323,7 @@ class FacialExpressionNode(Node):
             self.mp_drawing.draw_landmarks(
                 annotated,
                 face_landmarks,
-                self.mp_face_mesh.FACEMESH_CONTOURS,
+                self.mp_face_mesh_connections.FACEMESH_CONTOURS,
                 landmark_drawing_spec=None,
                 connection_drawing_spec=self.mp_styles.get_default_face_mesh_contours_style(),
             )
@@ -333,7 +355,8 @@ class FacialExpressionNode(Node):
         self.annotated_pub.publish(ann_msg)
 
     def destroy_node(self):
-        self.face_mesh.close()
+        if self.face_mesh is not None:
+            self.face_mesh.close()
         super().destroy_node()
 
 

--- a/src/hri_pkg/hri_pkg/gesture_recognition_node.py
+++ b/src/hri_pkg/hri_pkg/gesture_recognition_node.py
@@ -39,6 +39,12 @@ from std_msgs.msg import Bool, String
 
 try:
     import mediapipe as mp
+    from mediapipe.tasks.python import BaseOptions
+    from mediapipe.tasks.python.vision import (
+        HandLandmarker,
+        HandLandmarkerOptions,
+        RunningMode,
+    )
     MP_AVAILABLE = True
 except ImportError:
     MP_AVAILABLE = False
@@ -67,7 +73,10 @@ class GestureRecognitionNode(Node):
         super().__init__('gesture_recognition_node')
 
         # Parameters
-        self.declare_parameter('min_detection_confidence', 0.7)
+        self.declare_parameter('hand_model_path', '')
+        self.declare_parameter('num_hands', 1)
+        self.declare_parameter('min_hand_detection_confidence', 0.7)
+        self.declare_parameter('min_hand_presence_confidence', 0.5)
         self.declare_parameter('min_tracking_confidence', 0.5)
         self.declare_parameter('visualize', True)
         self.declare_parameter('active_only_on_trigger', True)   # trigger 시에만 활성화
@@ -75,7 +84,10 @@ class GestureRecognitionNode(Node):
         self.declare_parameter('wave_threshold', 0.08)           # WAVE x축 변화 임계값
         self.declare_parameter('gesture_confirm_frames', 3)      # 연속 N프레임 확인 후 발행
 
-        det_conf   = self.get_parameter('min_detection_confidence').value
+        hand_model_path = self.get_parameter('hand_model_path').value
+        num_hands = self.get_parameter('num_hands').value
+        det_conf   = self.get_parameter('min_hand_detection_confidence').value
+        hand_presence_conf = self.get_parameter('min_hand_presence_confidence').value
         trk_conf   = self.get_parameter('min_tracking_confidence').value
         self.visualize          = self.get_parameter('visualize').value
         self.active_on_trigger  = self.get_parameter('active_only_on_trigger').value
@@ -87,17 +99,25 @@ class GestureRecognitionNode(Node):
             self.get_logger().error('mediapipe not installed: pip install mediapipe')
             return
 
-        # MediaPipe initialization
-        self.mp_hands    = mp.solutions.hands
+        # MediaPipe initialization (Tasks API)
         self.mp_drawing  = mp.solutions.drawing_utils
         self.mp_styles   = mp.solutions.drawing_styles
-        self.hands = self.mp_hands.Hands(
-            static_image_mode=False,
-            max_num_hands=1,              # 캠퍼스 안내 상황: 주요 손 1개만
-            min_detection_confidence=det_conf,
+        self.mp_hands_connections = mp.solutions.hands
+        self.hands = None
+        if not hand_model_path:
+            self.get_logger().error(
+                'hand_model_path is empty. Set a valid MediaPipe .task model path.')
+            return
+
+        hand_options = HandLandmarkerOptions(
+            base_options=BaseOptions(model_asset_path=hand_model_path),
+            running_mode=RunningMode.VIDEO,
+            num_hands=num_hands,
+            min_hand_detection_confidence=det_conf,
+            min_hand_presence_confidence=hand_presence_conf,
             min_tracking_confidence=trk_conf,
-            model_complexity=0,           # 0=경량 (Jetson CPU 최적)
         )
+        self.hands = HandLandmarker.create_from_options(hand_options)
 
         # State
         self.is_active: bool = not self.active_on_trigger  # trigger OFF면 항상 활성
@@ -152,9 +172,13 @@ class GestureRecognitionNode(Node):
 
         h, w = cv_image.shape[:2]
         rgb = cv2.cvtColor(cv_image, cv2.COLOR_BGR2RGB)
-        results = self.hands.process(rgb)
+        mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
+        timestamp_ms = int(msg.header.stamp.sec * 1000 + msg.header.stamp.nanosec / 1_000_000)
+        if timestamp_ms <= 0:
+            timestamp_ms = int(time.monotonic() * 1000)
+        results = self.hands.detect_for_video(mp_image, timestamp_ms)
 
-        if not results.multi_hand_landmarks:
+        if not results.hand_landmarks:
             self._gesture_history.append(Gesture.NONE)
             self._wrist_x_history.clear()
             self._publish_gesture(Gesture.NONE, None, None)
@@ -163,8 +187,8 @@ class GestureRecognitionNode(Node):
             return
 
         # 첫 번째 손만 처리
-        hand_landmarks = results.multi_hand_landmarks[0]
-        lm = hand_landmarks.landmark  # 랜드마크 리스트 (0~20)
+        hand_landmarks = results.hand_landmarks[0]
+        lm = hand_landmarks  # 랜드마크 리스트 (0~20)
 
         # 손목 x이력 갱신 (WAVE 감지용) ───────────────────────────
         self._wrist_x_history.append(lm[WRIST].x)
@@ -335,7 +359,7 @@ class GestureRecognitionNode(Node):
             self.mp_drawing.draw_landmarks(
                 annotated,
                 hand_landmarks,
-                self.mp_hands.HAND_CONNECTIONS,
+                self.mp_hands_connections.HAND_CONNECTIONS,
                 self.mp_styles.get_default_hand_landmarks_style(),
                 self.mp_styles.get_default_hand_connections_style(),
             )
@@ -361,7 +385,8 @@ class GestureRecognitionNode(Node):
         self.annotated_pub.publish(ann_msg)
 
     def destroy_node(self):
-        self.hands.close()
+        if self.hands is not None:
+            self.hands.close()
         super().destroy_node()
 
 


### PR DESCRIPTION
### Motivation
- Update the hand and face perception nodes to the newer MediaPipe Tasks API for more flexible model loading and video-mode inference.
- Expose model and Tasks-specific runtime options as node parameters to allow using `.task` models and tuning detection/tracking behavior.
- Ensure proper resource cleanup for the Tasks landmarker objects when nodes are destroyed.

### Description
- Replaced `mp.solutions.hands.Hands` usage with `mediapipe.tasks.python.vision.HandLandmarker` and added `BaseOptions`/`HandLandmarkerOptions`/`RunningMode` support in `gesture_recognition_node.py` while preserving existing landmark index logic (WRIST, INDEX_TIP, etc.).
- Added gesture node parameters: `hand_model_path`, `num_hands`, `min_hand_detection_confidence`, `min_hand_presence_confidence`, and `min_tracking_confidence`, and created `HandLandmarker` via `HandLandmarker.create_from_options`.
- Switched frame handling to wrap `cv2` BGR→RGB arrays into `mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)` and call `detect_for_video(mp_image, timestamp_ms)` for gesture inference; changed result access from `multi_hand_landmarks` to `hand_landmarks`.
- Migrated `facial_expression_node.py` from Face Mesh to `mediapipe.tasks.python.vision.FaceLandmarker`, added `face_model_path` parameter, switched to `mp.Image` + `detect_for_video`, and updated result access from `multi_face_landmarks` to `face_landmarks`.
- Updated both nodes to use `mp.solutions.*` drawing utilities still for visualization (connections constants referenced via saved `mp.solutions` modules) and updated `destroy_node` to safely call `close()` only when the Tasks instance is non-`None`.

### Testing
- Ran Python bytecode compilation for both modified files with `python -m py_compile src/hri_pkg/hri_pkg/gesture_recognition_node.py src/hri_pkg/hri_pkg/facial_expression_node.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24d770064832c953ab71c9936e292)