### PR TITLE
Replace MediaPipe drawing helpers with OpenCV rendering and safe fallback

### DIFF
--- a/src/hri_pkg/hri_pkg/facial_expression_node.py
+++ b/src/hri_pkg/hri_pkg/facial_expression_node.py
@@ -68,6 +68,21 @@ MOUTH_BOTTOM = 14
 # Nose
 NOSE_TIP = 4
 
+# Face contour segments for stable OpenCV rendering (subset of mesh)
+FACE_CONTOUR_SEGMENTS = (
+    # face oval
+    [10, 338, 297, 332, 284, 251, 389, 356, 454, 323, 361, 288, 397, 365, 379, 378, 400, 377, 152, 148, 176, 149, 150, 136, 172, 58, 132, 93, 234, 127, 162, 21, 54, 103, 67, 109, 10],
+    # left eye
+    [33, 160, 158, 133, 153, 144, 33],
+    # right eye
+    [362, 385, 387, 263, 373, 380, 362],
+    # eyebrows
+    [70, 63, 105, 66, 107],
+    [300, 293, 334, 296, 336],
+    # lips outer
+    [61, 146, 91, 181, 84, 17, 314, 405, 321, 375, 291, 308, 324, 318, 402, 317, 14, 87, 178, 88, 95, 78, 61],
+)
+
 
 class Expression:
     SATISFIED   = 'SATISFIED'
@@ -108,9 +123,6 @@ class FacialExpressionNode(Node):
             return
 
         # MediaPipe Face Landmarker initialization (Tasks API)
-        self.mp_drawing   = mp.solutions.drawing_utils
-        self.mp_styles    = mp.solutions.drawing_styles
-        self.mp_face_mesh_connections = mp.solutions.face_mesh
         self.face_mesh = None
         face_model_path = self.get_parameter('face_model_path').value
         if not face_model_path:
@@ -188,7 +200,7 @@ class FacialExpressionNode(Node):
             self._expr_history.append(Expression.NEUTRAL)
             self._publish_expression(Expression.NEUTRAL, {}, msg)
             if self.visualize:
-                self._publish_annotated(cv_image, None, Expression.NEUTRAL, {}, msg)
+                self._safe_publish_annotated(cv_image, None, Expression.NEUTRAL, {}, msg)
             return
 
         face_lm = results.face_landmarks[0]
@@ -213,7 +225,7 @@ class FacialExpressionNode(Node):
             self._publish_command(confirmed, metrics)
 
         if self.visualize:
-            self._publish_annotated(
+            self._safe_publish_annotated(
                 cv_image, results.face_landmarks[0], confirmed, metrics, msg)
 
     def _extract_metrics(self, lm, w: int, h: int) -> dict:
@@ -317,16 +329,13 @@ class FacialExpressionNode(Node):
 
     def _publish_annotated(self, image: np.ndarray, face_landmarks,
                            expression: str, metrics: dict, original_msg):
+        if not self.visualize:
+            return
+
         annotated = image.copy()
 
         if face_landmarks:
-            self.mp_drawing.draw_landmarks(
-                annotated,
-                face_landmarks,
-                self.mp_face_mesh_connections.FACEMESH_CONTOURS,
-                landmark_drawing_spec=None,
-                connection_drawing_spec=self.mp_styles.get_default_face_mesh_contours_style(),
-            )
+            self._draw_face_contours(annotated, face_landmarks)
 
         color = {
             Expression.SATISFIED: (0, 255, 0),
@@ -353,6 +362,30 @@ class FacialExpressionNode(Node):
         ann_msg = self.bridge.cv2_to_imgmsg(annotated, encoding='bgr8')
         ann_msg.header = original_msg.header
         self.annotated_pub.publish(ann_msg)
+
+    def _safe_publish_annotated(self, image: np.ndarray, face_landmarks,
+                                expression: str, metrics: dict, original_msg):
+        try:
+            self._publish_annotated(image, face_landmarks, expression, metrics, original_msg)
+        except Exception as e:
+            self.get_logger().warning(
+                f'Expression annotation failed (inference continues): {e}')
+
+    @staticmethod
+    def _draw_face_contours(image: np.ndarray, face_landmarks):
+        h, w = image.shape[:2]
+
+        for segment in FACE_CONTOUR_SEGMENTS:
+            points = []
+            for idx in segment:
+                lm = face_landmarks[idx]
+                points.append((int(lm.x * w), int(lm.y * h)))
+            for i in range(len(points) - 1):
+                cv2.line(image, points[i], points[i + 1], (255, 200, 80), 1, cv2.LINE_AA)
+
+        for idx in (NOSE_TIP, MOUTH_LEFT, MOUTH_RIGHT, LEFT_EYEBROW_INNER, RIGHT_EYEBROW_INNER):
+            lm = face_landmarks[idx]
+            cv2.circle(image, (int(lm.x * w), int(lm.y * h)), 2, (0, 255, 0), -1, cv2.LINE_AA)
 
     def destroy_node(self):
         if self.face_mesh is not None:

--- a/src/hri_pkg/hri_pkg/gesture_recognition_node.py
+++ b/src/hri_pkg/hri_pkg/gesture_recognition_node.py
@@ -67,6 +67,16 @@ MIDDLE_TIP   = 12; MIDDLE_PIP   = 10
 RING_TIP     = 16; RING_PIP     = 14
 PINKY_TIP    = 20; PINKY_PIP    = 18
 
+# Hand landmark connections (MediaPipe Hands canonical graph)
+HAND_CONNECTIONS = (
+    (0, 1), (1, 2), (2, 3), (3, 4),
+    (0, 5), (5, 6), (6, 7), (7, 8),
+    (5, 9), (9, 10), (10, 11), (11, 12),
+    (9, 13), (13, 14), (14, 15), (15, 16),
+    (13, 17), (17, 18), (18, 19), (19, 20),
+    (0, 17),
+)
+
 
 class GestureRecognitionNode(Node):
     def __init__(self):
@@ -100,9 +110,6 @@ class GestureRecognitionNode(Node):
             return
 
         # MediaPipe initialization (Tasks API)
-        self.mp_drawing  = mp.solutions.drawing_utils
-        self.mp_styles   = mp.solutions.drawing_styles
-        self.mp_hands_connections = mp.solutions.hands
         self.hands = None
         if not hand_model_path:
             self.get_logger().error(
@@ -183,7 +190,7 @@ class GestureRecognitionNode(Node):
             self._wrist_x_history.clear()
             self._publish_gesture(Gesture.NONE, None, None)
             if self.visualize:
-                self._publish_annotated(cv_image, None, Gesture.NONE, msg)
+                self._safe_publish_annotated(cv_image, None, Gesture.NONE, msg)
             return
 
         # 첫 번째 손만 처리
@@ -215,7 +222,7 @@ class GestureRecognitionNode(Node):
             self.get_logger().info('WAVE detected → interaction_trigger forced publication')
 
         if self.visualize:
-            self._publish_annotated(cv_image, hand_landmarks, confirmed, msg)
+            self._safe_publish_annotated(cv_image, hand_landmarks, confirmed, msg)
 
     def _classify(self, lm, w: int, h: int) -> Gesture:
         """
@@ -353,16 +360,13 @@ class GestureRecognitionNode(Node):
         return None
 
     def _publish_annotated(self, image: np.ndarray, hand_landmarks, gesture: Gesture, original_msg):
+        if not self.visualize:
+            return
+
         annotated = image.copy()
 
         if hand_landmarks:
-            self.mp_drawing.draw_landmarks(
-                annotated,
-                hand_landmarks,
-                self.mp_hands_connections.HAND_CONNECTIONS,
-                self.mp_styles.get_default_hand_landmarks_style(),
-                self.mp_styles.get_default_hand_connections_style(),
-            )
+            self._draw_hand_landmarks(annotated, hand_landmarks)
 
         color = {
             Gesture.STOP:      (0, 0, 255),
@@ -383,6 +387,30 @@ class GestureRecognitionNode(Node):
         ann_msg = self.bridge.cv2_to_imgmsg(annotated, encoding='bgr8')
         ann_msg.header = original_msg.header
         self.annotated_pub.publish(ann_msg)
+
+    def _safe_publish_annotated(self, image: np.ndarray, hand_landmarks,
+                                gesture: Gesture, original_msg):
+        try:
+            self._publish_annotated(image, hand_landmarks, gesture, original_msg)
+        except Exception as e:
+            self.get_logger().warning(f'Gesture annotation failed (inference continues): {e}')
+
+    @staticmethod
+    def _draw_hand_landmarks(image: np.ndarray, hand_landmarks):
+        h, w = image.shape[:2]
+
+        for start_idx, end_idx in HAND_CONNECTIONS:
+            p1 = hand_landmarks[start_idx]
+            p2 = hand_landmarks[end_idx]
+            x1, y1 = int(p1.x * w), int(p1.y * h)
+            x2, y2 = int(p2.x * w), int(p2.y * h)
+            cv2.line(image, (x1, y1), (x2, y2), (80, 180, 255), 2, cv2.LINE_AA)
+
+        for idx, landmark in enumerate(hand_landmarks):
+            cx, cy = int(landmark.x * w), int(landmark.y * h)
+            radius = 4 if idx in (WRIST, THUMB_TIP, INDEX_TIP) else 3
+            color = (0, 255, 0) if idx in (THUMB_TIP, INDEX_TIP, MIDDLE_TIP, RING_TIP, PINKY_TIP) else (255, 255, 255)
+            cv2.circle(image, (cx, cy), radius, color, -1, cv2.LINE_AA)
 
     def destroy_node(self):
         if self.hands is not None:


### PR DESCRIPTION
### Motivation
- Reduce fragile dependency on `mediapipe.solutions` drawing helpers and improve annotation API stability by rendering landmarks with OpenCV.
- Ensure annotation failures never interrupt inference or message publication by isolating drawing to annotate-only error boundaries.
- Lower CPU usage when visualization is disabled by skipping draw operations entirely.

### Description
- Removed reliance on `self.mp_drawing`/`self.mp_styles` drawing helpers and replaced them with local renderers using OpenCV in `gesture_recognition_node.py` and `facial_expression_node.py`.
- Added `HAND_CONNECTIONS` and `FACE_CONTOUR_SEGMENTS` constants and implemented ` _draw_hand_landmarks()` and `_draw_face_contours()` that use `cv2.line`/`cv2.circle` for stable rendering.
- Wrapped annotation calls with `_safe_publish_annotated()` which catches exceptions and logs warnings so inference/publishing continues if drawing fails.
- Added defensive early return in `_publish_annotated()` when `visualize` is false and updated call sites to use the safe publisher.

### Testing
- Ran Python bytecode compilation via `python -m compileall src/hri_pkg/hri_pkg/gesture_recognition_node.py src/hri_pkg/hri_pkg/facial_expression_node.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c250fddc78832c96d7afa2ec7661a5)