### PR TITLE
Add confidence checks, handedness correction, and publish cooldowns to gesture and expression nodes

### DIFF
--- a/src/hri_pkg/hri_pkg/facial_expression_node.py
+++ b/src/hri_pkg/hri_pkg/facial_expression_node.py
@@ -101,6 +101,8 @@ class FacialExpressionNode(Node):
         self.declare_parameter('visualize', True)
         self.declare_parameter('active_only_on_trigger', True)
         self.declare_parameter('confirm_frames', 5)
+        self.declare_parameter('publish_cooldown_sec', 3.0)
+        self.declare_parameter('min_face_presence_confidence', 0.5)
 
         # Face expression thresholds (needs to be tuned)
         self.declare_parameter('smile_threshold', 0.02)
@@ -113,6 +115,9 @@ class FacialExpressionNode(Node):
         self.visualize         = self.get_parameter('visualize').value
         self.active_on_trigger = self.get_parameter('active_only_on_trigger').value
         self.confirm_frames    = self.get_parameter('confirm_frames').value
+        self.publish_cooldown_sec = self.get_parameter('publish_cooldown_sec').value
+        self.min_face_presence_confidence = self.get_parameter(
+            'min_face_presence_confidence').value
         self.smile_thresh      = self.get_parameter('smile_threshold').value
         self.frown_thresh      = self.get_parameter('frown_threshold').value
         self.brow_frown_thresh = self.get_parameter('brow_frown_threshold').value
@@ -135,9 +140,9 @@ class FacialExpressionNode(Node):
             running_mode=RunningMode.VIDEO,
             num_faces=1,
             min_face_detection_confidence=det_conf,
-            min_face_presence_confidence=det_conf,
+            min_face_presence_confidence=self.min_face_presence_confidence,
             min_tracking_confidence=trk_conf,
-            output_face_blendshapes=False,
+            output_face_blendshapes=True,
             output_facial_transformation_matrixes=False,
         )
         self.face_mesh = FaceLandmarker.create_from_options(face_options)
@@ -150,6 +155,8 @@ class FacialExpressionNode(Node):
         # Counters for expression-specific logic
         self._confused_count: int = 0
         self._confused_trigger_count: int = 3
+        self._last_published_command: str | None = None
+        self._last_command_publish_time: float = 0.0
 
         # Subscribers
         self.create_subscription(
@@ -201,6 +208,28 @@ class FacialExpressionNode(Node):
             self._publish_expression(Expression.NEUTRAL, {}, msg)
             if self.visualize:
                 self._safe_publish_annotated(cv_image, None, Expression.NEUTRAL, {}, msg)
+            return
+
+        face_presence_conf = None
+        if (
+            results.face_blendshapes
+            and len(results.face_blendshapes) > 0
+            and len(results.face_blendshapes[0]) > 0
+        ):
+            # MediaPipe Tasks: blendshape score is a practical proxy for face presence confidence.
+            face_presence_conf = max(c.score for c in results.face_blendshapes[0])
+
+        if (
+            face_presence_conf is not None
+            and face_presence_conf < self.min_face_presence_confidence
+        ):
+            self._expr_history.clear()
+            self._confused_count = 0
+            self._publish_expression(Expression.NEUTRAL, {'presence_conf': round(face_presence_conf, 4)}, msg)
+            if self.visualize:
+                self._safe_publish_annotated(
+                    cv_image, results.face_landmarks[0], Expression.NEUTRAL,
+                    {'presence_conf': round(face_presence_conf, 4)}, msg)
             return
 
         face_lm = results.face_landmarks[0]
@@ -324,7 +353,16 @@ class FacialExpressionNode(Node):
 
         msg = String()
         msg.data = json.dumps(command, ensure_ascii=False)
+        now_sec = time.monotonic()
+        command_key = command['command']
+        if (
+            command_key == self._last_published_command
+            and (now_sec - self._last_command_publish_time) < self.publish_cooldown_sec
+        ):
+            return
         self.command_pub.publish(msg)
+        self._last_published_command = command_key
+        self._last_command_publish_time = now_sec
         self.get_logger().info(f'Expression command: {command["command"]}')
 
     def _publish_annotated(self, image: np.ndarray, face_landmarks,

--- a/src/hri_pkg/hri_pkg/gesture_recognition_node.py
+++ b/src/hri_pkg/hri_pkg/gesture_recognition_node.py
@@ -93,6 +93,9 @@ class GestureRecognitionNode(Node):
         self.declare_parameter('wave_history_len', 10)           # WAVE 판정용 이력 길이
         self.declare_parameter('wave_threshold', 0.08)           # WAVE x축 변화 임계값
         self.declare_parameter('gesture_confirm_frames', 3)      # 연속 N프레임 확인 후 발행
+        self.declare_parameter('publish_cooldown_sec', 1.5)      # 동일 명령 중복 발행 억제
+        self.declare_parameter('min_result_confidence', 0.5)     # 결과 사용 최소 confidence
+        self.declare_parameter('use_handedness_correction', True)
 
         hand_model_path = self.get_parameter('hand_model_path').value
         num_hands = self.get_parameter('num_hands').value
@@ -104,6 +107,9 @@ class GestureRecognitionNode(Node):
         wave_history_len        = self.get_parameter('wave_history_len').value
         self.wave_thresh        = self.get_parameter('wave_threshold').value
         self.confirm_frames     = self.get_parameter('gesture_confirm_frames').value
+        self.publish_cooldown_sec = self.get_parameter('publish_cooldown_sec').value
+        self.min_result_confidence = self.get_parameter('min_result_confidence').value
+        self.use_handedness_correction = self.get_parameter('use_handedness_correction').value
 
         if not MP_AVAILABLE:
             self.get_logger().error('mediapipe not installed: pip install mediapipe')
@@ -133,6 +139,8 @@ class GestureRecognitionNode(Node):
         self._wrist_x_history: deque = deque(maxlen=wave_history_len)
 
         self._gesture_history: deque = deque(maxlen=self.confirm_frames)
+        self._last_published_command: str | None = None
+        self._last_command_publish_time: float = 0.0
 
         # Subscribers
         self.create_subscription(
@@ -195,13 +203,20 @@ class GestureRecognitionNode(Node):
 
         # 첫 번째 손만 처리
         hand_landmarks = results.hand_landmarks[0]
+        handedness_label = None
+        result_confidence = None
+        if results.handedness and len(results.handedness) > 0 and len(results.handedness[0]) > 0:
+            category = results.handedness[0][0]
+            handedness_label = category.category_name
+            result_confidence = category.score
         lm = hand_landmarks  # 랜드마크 리스트 (0~20)
 
         # 손목 x이력 갱신 (WAVE 감지용) ───────────────────────────
-        self._wrist_x_history.append(lm[WRIST].x)
+        if result_confidence is None or result_confidence >= self.min_result_confidence:
+            self._wrist_x_history.append(lm[WRIST].x)
 
         # 제스처 분류 ──────────────────────────────────────────────
-        gesture = self._classify(lm, w, h)
+        gesture = self._classify(lm, w, h, handedness_label)
 
         # 연속 confirm_frames 동안 같은 제스처여야 발행 (노이즈 방지)
         self._gesture_history.append(gesture)
@@ -224,7 +239,7 @@ class GestureRecognitionNode(Node):
         if self.visualize:
             self._safe_publish_annotated(cv_image, hand_landmarks, confirmed, msg)
 
-    def _classify(self, lm, w: int, h: int) -> Gesture:
+    def _classify(self, lm, w: int, h: int, handedness_label: str | None) -> Gesture:
         """
         손 랜드마크 기하학적 분석으로 제스처 분류
 
@@ -232,7 +247,7 @@ class GestureRecognitionNode(Node):
           - TIP의 y좌표 < PIP의 y좌표 → 펼쳐짐 (이미지 좌표계: 위가 y=0)
           - 엄지는 x축으로 판단 (왼손/오른손 방향 고려)
         """
-        fingers_extended = self._get_extended_fingers(lm)
+        fingers_extended = self._get_extended_fingers(lm, handedness_label)
         # fingers_extended: [thumb, index, middle, ring, pinky] bool list
 
         # STOP: 5개 모두 펼침 ──────────────────────────────────────
@@ -256,14 +271,19 @@ class GestureRecognitionNode(Node):
 
         return Gesture.NONE
 
-    def _get_extended_fingers(self, lm) -> list[bool]:
+    def _get_extended_fingers(self, lm, handedness_label: str | None = None) -> list[bool]:
         """
         각 손가락 펼침 여부 반환 [thumb, index, middle, ring, pinky]
         엄지: tip이 mcp보다 바깥쪽 (x축)
         나머지: tip이 pip보다 위 (y축, 이미지 좌표)
         """
-        # 엄지 — x축 기준 (왼손 기준; 오른손이면 부호 반전되나 근사값으로 사용)
-        thumb_ext = lm[THUMB_TIP].x < lm[THUMB_MCP].x
+        # 엄지 — x축 기준 (handedness 사용 시 좌/우 손 기준 보정)
+        thumb_dx = lm[THUMB_TIP].x - lm[THUMB_MCP].x
+        if self.use_handedness_correction and handedness_label in ('Left', 'Right'):
+            handedness_sign = -1.0 if handedness_label == 'Left' else 1.0
+            thumb_ext = (thumb_dx * handedness_sign) > 0
+        else:
+            thumb_ext = thumb_dx < 0
 
         index_ext  = lm[INDEX_TIP].y  < lm[INDEX_PIP].y
         middle_ext = lm[MIDDLE_TIP].y < lm[MIDDLE_PIP].y
@@ -334,9 +354,18 @@ class GestureRecognitionNode(Node):
         # gesture to command
         command = self._gesture_to_command(gesture, direction)
         if command:
+            command_key = command['command']
+            now_sec = time.monotonic()
+            if (
+                command_key == self._last_published_command
+                and (now_sec - self._last_command_publish_time) < self.publish_cooldown_sec
+            ):
+                return
             c_msg = String()
             c_msg.data = json.dumps(command, ensure_ascii=False)
             self.command_pub.publish(c_msg)
+            self._last_published_command = command_key
+            self._last_command_publish_time = now_sec
             self.get_logger().info(f'Gesture command: {command}')
 
     def _gesture_to_command(self, gesture: Gesture, direction: dict | None) -> dict | None:


### PR DESCRIPTION
### Motivation
- Reduce duplicate command/TTS spam by suppressing identical publishes within a short cooldown window. 
- Improve thumb extension detection by using MediaPipe handedness (Left/Right) to correct x-axis sign when available. 
- Avoid polluting motion/history and expression confirmation with low-confidence model results so noisy frames do not trigger gestures or commands.

### Description
- `gesture_recognition_node.py`: added parameters `publish_cooldown_sec`, `min_result_confidence`, and `use_handedness_correction`, read MediaPipe `handedness` and `score`, gate wrist x-history updates by `min_result_confidence`, apply handedness-aware thumb x sign correction in `_get_extended_fingers`, and suppress duplicate gesture commands using `_last_published_command` + monotonic cooldown. 
- `facial_expression_node.py`: added parameters `publish_cooldown_sec` and `min_face_presence_confidence`, enabled `output_face_blendshapes` in the FaceLandmarker options, use blendshape scores as a proxy for face-presence confidence to skip/clear low-confidence frames, and suppress duplicate expression commands (`REPEAT_GUIDANCE`, `GUIDANCE_COMPLETE`) with a cooldown cache. 
- Minor state: both nodes now maintain `_last_published_command` and `_last_command_publish_time` to implement cooldown suppression, and `gesture_recognition_node` avoids appending low-confidence wrist positions to the wave history.

### Testing
- Ran `python3 -m py_compile src/hri_pkg/hri_pkg/gesture_recognition_node.py src/hri_pkg/hri_pkg/facial_expression_node.py` and compilation succeeded. 
- No additional runtime/integration tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2526aede8832c95ffffd94b0dd2db)