### PR TITLE
Use dynamic viewport units and safe-area insets for mobile layout

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -13,6 +13,7 @@
   grid-template-rows: 44px 1fr;
   width: 100%;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   transition: grid-template-columns 0.22s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -41,13 +42,18 @@
   grid-row: 2;
   overflow: hidden;
   min-height: 0;
+  box-sizing: border-box;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   background: var(--bg-0);
 }
 
 /* Dimmed area shown when overlay sidebar is open */
 .app-sidebar-backdrop {
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: env(safe-area-inset-bottom, 0px);
   border: 0;
   background: rgba(2, 6, 14, 0.52);
   backdrop-filter: blur(1px);
@@ -71,10 +77,20 @@
   top: 0;
   left: 0;
   height: 100vh;
+  height: 100dvh;
   width: 48px;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  box-sizing: border-box;
   transition: width 0.22s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .app.sb-overlay.sb-expanded .app-sidebar {
   width: min(280px, calc(100vw - 40px));
+}
+
+@media (max-width: 768px) {
+  .app-main {
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
 }

--- a/web/src/components/MobileStack.css
+++ b/web/src/components/MobileStack.css
@@ -71,5 +71,6 @@
 .ms-body {
   min-height: 200px;
   max-height: 60vh;
+  max-height: 60dvh;
   overflow: auto;
 }


### PR DESCRIPTION
### Motivation
- Adapt the app layout to dynamic viewport changes on mobile Safari (address bar / toolbar) by preferring `dvh` over fixed `vh` where appropriate.
- Prevent content and interactive areas from being obscured by iOS home indicator / notch by applying safe-area insets to main content and overlay elements.
- Ensure overlay backdrop and fixed sidebar respect safe-area at the bottom so touch interactions are not blocked.
- Improve mobile scrolling behavior for panels to avoid content being clipped at the bottom.

### Description
- Prefer `100dvh` (with `100vh` fallback) on the root `.app` and overlay sidebar to handle dynamic viewport height changes on mobile browsers.
- Add `padding-bottom: env(safe-area-inset-bottom, 0px)` and `box-sizing: border-box` to `.app-main` to avoid content being obscured by iOS safe-area, and enable touch-friendly scrolling with `-webkit-overflow-scrolling: touch` in a mobile media query.
- Change the overlay sidebar backdrop positioning to use `bottom: env(safe-area-inset-bottom, 0px)` instead of `inset: 0` so the dimmed backdrop does not cover the safe-area bottom.
- Apply `padding-bottom: env(safe-area-inset-bottom, 0px)`, `box-sizing: border-box`, and `height: 100dvh` to `.app.sb-overlay .app-sidebar` so the overlay respects safe-area and dynamic viewport height.
- Prefer `max-height: 60dvh` for mobile stacked panel bodies to avoid clipping when dynamic viewport changes occur.
- Files changed: `web/src/App.css`, `web/src/components/MobileStack.css`.

### Testing
- Ran linting with `npm run lint` in `web/`, which failed due to pre-existing ESLint errors elsewhere in the codebase that are unrelated to these CSS-only changes.
- No automated visual or runtime tests were added for this styling update in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c26b000f78832cbb5cfab4ea53044c)