### PR TITLE
fix: restore collapsed sidebar tooltip visibility

### DIFF
--- a/web/src/components/Sidebar.css
+++ b/web/src/components/Sidebar.css
@@ -73,6 +73,10 @@
   overflow: hidden;
 }
 
+.sidebar.collapsed .sb-search-cell {
+  overflow: visible;
+}
+
 /* Collapsed: icon button fills the cell */
 .sb-search-btn {
   position: relative;
@@ -154,6 +158,10 @@
   overflow-y: auto;
   overflow-x: hidden;
   min-height: 0;
+}
+
+.sidebar.collapsed .sb-nav {
+  overflow-x: visible;
 }
 
 .sb-empty {
@@ -429,6 +437,7 @@
 }
 
 .sidebar.collapsed .sb-open:hover .sb-tooltip,
+.sidebar.collapsed .sb-search-btn:hover .sb-tooltip,
 .sidebar.collapsed .sb-cat-header:hover .sb-tooltip,
 .sidebar.collapsed .sb-leaf:hover .sb-tooltip,
 .sidebar.collapsed .sb-status:hover .sb-tooltip {


### PR DESCRIPTION
### Motivation
- Collapsed sidebar tooltips were being clipped by parent overflow rules, preventing hover labels from appearing outside the rail.
- The change aims to allow tooltip panels to escape the collapsed search row and nav rail while keeping normal overflow behavior when expanded.

### Description
- Allow the search row to expose overflow only in collapsed mode with `.sidebar.collapsed .sb-search-cell { overflow: visible; }` in `web/src/components/Sidebar.css`.
- Permit tooltip overflow from the nav rail in collapsed mode by adding `.sidebar.collapsed .sb-nav { overflow-x: visible; }`.
- Add the missing hover selector for the collapsed search trigger: `.sidebar.collapsed .sb-search-btn:hover .sb-tooltip` so the search button shows its tooltip when collapsed.
- Verified `Sidebar.jsx` renders `.sb-tooltip` for collapsed targets (`sb-open`, `sb-search-btn`, `sb-cat-header`, `sb-status`) and checked `z-index` relationships so tooltips are not hidden behind the app backdrop.

### Testing
- Ran `rg`/search checks for `sb-tooltip` and collapsed trigger classes which confirmed tooltip elements exist in `Sidebar.jsx` (passed).
- Ran `npm --prefix web run lint` which failed due to unrelated, pre-existing lint errors in other files and not related to the CSS change (failed).
- Confirmed the CSS patch was applied to `web/src/components/Sidebar.css` and the tooltip visibility selectors were added (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c26d0ffc28832ca65260adb14cdc4d)