### PR TITLE
Pass App themeMode to Sidebar and drive Sidebar theme from it

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -79,6 +79,7 @@ export default function App() {
     <div className={`app ${sidebarExpanded ? 'sb-expanded' : ''} ${isOverlaySidebar ? 'sb-overlay' : ''}`}>
       <div className="app-sidebar">
         <Sidebar
+          themeMode={themeMode}
           expanded={sidebarExpanded}
           onExpand={() => setSidebarExpanded(true)}
           onCollapse={() => setSidebarExpanded(false)}

--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -120,7 +120,7 @@ function CategoryBlock({ node, onSelect, expanded, searchActive, onExpandSidebar
 
 // ── Main Sidebar ──────────────────────────────────────────────────────────────
 
-export default function Sidebar({ expanded, onExpand, onCollapse, activeId, onSelect, tree }) {
+export default function Sidebar({ themeMode, expanded, onExpand, onCollapse, activeId, onSelect, tree }) {
   const connected  = useStore(s => s.connected);
   const isDemoMode = useStore(s => s.isDemoMode);
 
@@ -128,22 +128,18 @@ export default function Sidebar({ expanded, onExpand, onCollapse, activeId, onSe
   const statusClass = connected ? 'connected' : isDemoMode ? 'demo' : '';
 
   // Resolve dark/light for logo variant
-  const [isDark, setIsDark] = useState(() => {
-    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme-mode') : null;
-    if (stored === 'dark')  return true;
-    if (stored === 'light') return false;
-    return typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches;
-  });
+  const [autoIsDark, setAutoIsDark] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
 
   useEffect(() => {
-    const stored = localStorage.getItem('theme-mode') || 'auto';
-    if (stored !== 'auto') { setIsDark(stored === 'dark'); return; }
+    if (themeMode !== 'auto') return;
+
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const apply = e => setIsDark(e.matches);
-    setIsDark(mq.matches);
+    const apply = e => setAutoIsDark(e.matches);
     mq.addEventListener('change', apply);
     return () => mq.removeEventListener('change', apply);
-  }, []);
+  }, [themeMode]);
 
   const [query,        setQuery]        = useState('');
   const [pendingFocus, setPendingFocus] = useState(false);
@@ -159,6 +155,7 @@ export default function Sidebar({ expanded, onExpand, onCollapse, activeId, onSe
     }
   }, [expanded, pendingFocus]);
 
+  const isDark = themeMode === 'dark' || (themeMode === 'auto' && autoIsDark);
   const FullLogo = isDark ? DoriLogoFullDark : DoriLogoFull;
 
   return (


### PR DESCRIPTION
### Motivation
- Ensure `Header` and `Sidebar` use a single source of truth for theme selection so UI stays consistent.
- Remove duplicated `localStorage` reads from `Sidebar` and make the component follow `App`'s `themeMode` state instead.
- Only subscribe to system `prefers-color-scheme` when `themeMode === 'auto'` to avoid unnecessary listeners and ghost registrations.

### Description
- Pass `themeMode` from `App` into `Sidebar` by adding `themeMode={themeMode}` to the `Sidebar` invocation in `web/src/App.jsx`.
- Update `Sidebar` signature to accept `themeMode` and remove direct `localStorage.getItem('theme-mode')` usage in `web/src/components/Sidebar.jsx`.
- Replace internal dark-mode state with an `autoIsDark` state for tracking system preference and compute `isDark` from `themeMode` plus `autoIsDark` so `themeMode === 'dark'`/`'light'` take precedence.
- Change the media-query effect to `useEffect(..., [themeMode])` so the `prefers-color-scheme` listener is only registered when `themeMode === 'auto'` and is properly cleaned up on mode changes.

### Testing
- Ran `npm run lint` in `web/`, which failed due to pre-existing lint issues elsewhere in the repo, and this change did not introduce new lint errors according to the run.
- Verified the modified files are syntactically valid by running the linter (no new syntax errors introduced by these edits).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c285ab5264832cb44f8675194fa4a5)