### PR TITLE
Remove sidebar logo fade-in animation

### DIFF
--- a/web/src/components/Sidebar.css
+++ b/web/src/components/Sidebar.css
@@ -71,7 +71,6 @@
   align-items: center;
   flex: 1;
   min-width: 0;
-  animation: sb-fade-in 0.18s ease;
 }
 
 .sb-logo-text-svg {


### PR DESCRIPTION
### Motivation
- Prevent layout shift caused by the logo animating with `transform` while preserving other sidebar fade usages and layout constraints.

### Description
- Removed `animation: sb-fade-in 0.18s ease;` from `.sb-logo` in `web/src/components/Sidebar.css`, kept the `@keyframes sb-fade-in` definition because it is still referenced by `.sb-empty` and `.sb-status-label`, and left `sb-logo-anchor` (48px) and `sb-icon-svg` (24px) unchanged to maintain layout stability.

### Testing
- Ran `rg -n "sb-fade-in|@keyframes" web/src/components/Sidebar.css` to confirm usages and then committed the file with `git commit`; the search and commit commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28e3afbcc832c8d770f0edde02deb)