### PR TITLE
Fix Dori logo SVG gradient id collisions in inline renders

### DIFF
--- a/web/src/assets/logo/logo-icon-color.svg
+++ b/web/src/assets/logo/logo-icon-color.svg
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1000 1000">
   <defs>
-    <style>
-      .cls-1 {
-        fill: url(#linear-gradient);
-      }
-    </style>
-    <linearGradient id="linear-gradient" x1="67.24" y1="249.4" x2="933.41" y2="749.48" gradientUnits="userSpaceOnUse">
+    <linearGradient id="dori-logo-gradient" x1="67.24" y1="249.4" x2="933.41" y2="749.48" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#d8e7f7"/>
       <stop offset=".06" stop-color="#cee3f5"/>
       <stop offset=".16" stop-color="#b5d8f0"/>
@@ -17,5 +12,5 @@
       <stop offset=".99" stop-color="#00599b"/>
     </linearGradient>
   </defs>
-  <path class="cls-1" d="M220,914.3C87.25,824.4,0,672.39,0,500S87.8,174.64,221.26,84.86M500,0c-40.96,0-80.77,4.93-118.88,14.22v971.56c38.1,9.29,77.91,14.22,118.88,14.22,276.14,0,500-223.86,500-500S776.14,0,500,0Z"/>
+  <path fill="url(#dori-logo-gradient)" d="M220,914.3C87.25,824.4,0,672.39,0,500S87.8,174.64,221.26,84.86M500,0c-40.96,0-80.77,4.93-118.88,14.22v971.56c38.1,9.29,77.91,14.22,118.88,14.22,276.14,0,500-223.86,500-500S776.14,0,500,0Z"/>
 </svg>

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -6,7 +6,21 @@ import svgr from 'vite-plugin-svgr'
 export default defineConfig({
   plugins: [
     react(),
-    svgr(),
+    svgr({
+      svgrOptions: {
+        svgoConfig: {
+          plugins: [
+            {
+              name: 'prefixIds',
+              params: {
+                prefix: 'dori',
+                delim: '-',
+              },
+            },
+          ],
+        },
+      },
+    }),
     {
       name: 'strip-roslib-cdn',
       transform(code, id) {


### PR DESCRIPTION
### Motivation
- Prevent id collisions when the colored Dori logo SVG is inlined multiple times by making its gradient id unique and avoiding CSS class-based fills.
- Reduce the risk of SVG id conflicts across the app by enabling SVGO `prefixIds` for the `svgr` pipeline so imported SVGs are namespaced.
- Preserve the existing Sidebar expanded/collapsed rendering branch so the UI continues to render `DoriLogoIconColor` when expanded and the mono icon when collapsed.

### Description
- Updated `web/src/assets/logo/logo-icon-color.svg` to remove the `<style>`/`.cls-1` dependency, renamed the gradient id from `linear-gradient` to `dori-logo-gradient`, and changed the `<path>` to use `fill="url(#dori-logo-gradient)"` directly.
- Configured `vite-plugin-svgr` in `web/vite.config.js` to enable SVGO `prefixIds` via `svgr({ svgrOptions: { svgoConfig: { plugins: [{ name: 'prefixIds', params: { prefix: 'dori', delim: '-' } }] } } })` to avoid id collisions on inlined SVGs.
- Left `web/src/components/Sidebar.jsx` branching logic intact so the expanded vs collapsed logo rendering remains unchanged.

### Testing
- Ran `cd web && npm run build`, which initially failed due to a missing `@svgr/plugin-svgo` when explicit SVGR plugins were referenced, and then after adjusting the `svgr` options the build succeeded.
- Final `npm run build` completed successfully and produced a production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c291f53f30832cb2a3c520748658cc)