### PR TITLE
feat(web): lazy-load panel components and add Suspense loading UI

### DIFF
--- a/web/src/components/FloatingPanel.css
+++ b/web/src/components/FloatingPanel.css
@@ -87,6 +87,16 @@
   position: relative;
 }
 
+.fp-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  color: var(--text-2);
+  font-size: 12px;
+  letter-spacing: 0.2px;
+}
+
 /* ── Resize handle ── */
 .fp-resize-handle {
   position: absolute;

--- a/web/src/components/FloatingPanel.jsx
+++ b/web/src/components/FloatingPanel.jsx
@@ -5,7 +5,7 @@
  * for consistent cross-browser behavior including Safari.
  */
 
-import { useRef } from 'react';
+import { Suspense, useRef } from 'react';
 import { useStore } from '../core/store';
 import { useDraggable } from '../hooks/useDraggable';
 import './FloatingPanel.css';
@@ -113,7 +113,9 @@ export default function FloatingPanel({ panel }) {
       {/* ── Body ── */}
       {!minimized && (
         <div className="fp-body">
-          <Component />
+          <Suspense fallback={<div className="fp-loading">Loading panel…</div>}>
+            <Component />
+          </Suspense>
         </div>
       )}
 

--- a/web/src/components/MobileStack.css
+++ b/web/src/components/MobileStack.css
@@ -74,3 +74,13 @@
   max-height: 60dvh;
   overflow: auto;
 }
+
+.ms-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  color: var(--text-2);
+  font-size: 12px;
+  letter-spacing: 0.2px;
+}

--- a/web/src/components/MobileStack.jsx
+++ b/web/src/components/MobileStack.jsx
@@ -6,6 +6,7 @@
  * No dragging, no z-index management.
  */
 
+import { Suspense } from 'react';
 import { useStore } from '../core/store';
 import './MobileStack.css';
 
@@ -37,7 +38,9 @@ function MobilePanel({ panel }) {
       </div>
       {!minimized && (
         <div className="ms-body">
-          <Component />
+          <Suspense fallback={<div className="ms-loading">Loading panel…</div>}>
+            <Component />
+          </Suspense>
         </div>
       )}
     </div>

--- a/web/src/panelTree.jsx
+++ b/web/src/panelTree.jsx
@@ -5,32 +5,33 @@
  * Keep `Control / Perception & Intelligence / System` leaves under matching folders.
  */
 
-import STTPanel from './panels/hri/STTPanel';
-import WakeWordPanel from './panels/hri/WakeWordPanel';
-import StateMonitorPanel from './panels/hri/StateMonitorPanel';
-import EventLogPanel from './panels/system/EventLogPanel';
+import { lazy } from 'react';
 
-import FaceDisplayPanel from './panels/hri/FaceDisplayPanel';
-import EmotionPalettePanel from './panels/hri/EmotionPalettePanel';
-import ConversationPanel from './panels/hri/ConversationPanel';
+const STTPanel = lazy(() => import('./panels/hri/STTPanel'));
+const WakeWordPanel = lazy(() => import('./panels/hri/WakeWordPanel'));
+const TTSInjectPanel = lazy(() => import('./panels/hri/TTSInjectPanel'));
+const StateMonitorPanel = lazy(() => import('./panels/hri/StateMonitorPanel'));
+const ConversationPanel = lazy(() => import('./panels/hri/ConversationPanel'));
+const FaceDisplayPanel = lazy(() => import('./panels/hri/FaceDisplayPanel'));
+const EmotionPalettePanel = lazy(() => import('./panels/hri/EmotionPalettePanel'));
 
-import CubeViewerPanel from './panels/control/CubeViewerPanel';
-import PieceStatePanel from './panels/control/PieceStatePanel';
-import RotationControlPanel from './panels/control/RotationControlPanel';
+const CubeViewerPanel = lazy(() => import('./panels/control/CubeViewerPanel'));
+const RotationControlPanel = lazy(() => import('./panels/control/RotationControlPanel'));
+const PieceStatePanel = lazy(() => import('./panels/control/PieceStatePanel'));
 
-import VisionPanel from './panels/perception/VisionPanel';
-import LLMInjectPanel from './panels/perception/LLMInjectPanel';
-import MenuParserPanel from './panels/perception/MenuParserPanel';
-import IndexBuilderPanel from './panels/perception/IndexBuilderPanel';
-import DocumentBrowserPanel from './panels/perception/DocumentBrowserPanel';
-import BuildingEditorPanel from './panels/perception/BuildingEditorPanel';
-import TTSInjectPanel from './panels/hri/TTSInjectPanel';
+const VisionPanel = lazy(() => import('./panels/perception/VisionPanel'));
+const LLMInjectPanel = lazy(() => import('./panels/perception/LLMInjectPanel'));
+const MenuParserPanel = lazy(() => import('./panels/perception/MenuParserPanel'));
+const IndexBuilderPanel = lazy(() => import('./panels/perception/IndexBuilderPanel'));
+const DocumentBrowserPanel = lazy(() => import('./panels/perception/DocumentBrowserPanel'));
+const BuildingEditorPanel = lazy(() => import('./panels/perception/BuildingEditorPanel'));
 
-import TopicDiagnosticsPanel from './panels/system/TopicDiagnosticsPanel';
-import ConnectionInfoPanel from './panels/system/ConnectionInfoPanel';
-import MetricsPanel from './panels/system/MetricsPanel';
-import TopicPublisherPanel from './panels/system/TopicPublisherPanel';
-import DeployStatusPanel from './panels/system/DeployStatusPanel';
+const ConnectionInfoPanel = lazy(() => import('./panels/system/ConnectionInfoPanel'));
+const TopicDiagnosticsPanel = lazy(() => import('./panels/system/TopicDiagnosticsPanel'));
+const MetricsPanel = lazy(() => import('./panels/system/MetricsPanel'));
+const EventLogPanel = lazy(() => import('./panels/system/EventLogPanel'));
+const TopicPublisherPanel = lazy(() => import('./panels/system/TopicPublisherPanel'));
+const DeployStatusPanel = lazy(() => import('./panels/system/DeployStatusPanel'));
 
 import HriIcon        from './assets/icons/icon-hri.svg?react';
 import ControlIcon    from './assets/icons/icon-control.svg?react';


### PR DESCRIPTION
### Motivation
- Reduce initial app bundle size by loading heavy panel code only when a panel is opened.
- Keep PANEL_TREE leaves referencing components so the panel open logic stays the same while making those components dynamic.
- Improve UX during lazy-load by showing a consistent loading placeholder instead of a blank/flicker.

### Description
- Replaced static panel imports in `web/src/panelTree.jsx` with `React.lazy(() => import(...))` so leaf `component` entries are lazy components (load-on-open).
- Added `Suspense` boundaries around panel rendering in `web/src/components/FloatingPanel.jsx` and `web/src/components/MobileStack.jsx` with small text fallbacks (`Loading panel…`).
- Added lightweight loading styles `.fp-loading` and `.ms-loading` in `FloatingPanel.css` and `MobileStack.css` to center the fallback and provide a minimum height to reduce visual flicker.
- Ensured both desktop (floating) and mobile stack rendering paths show the fallback while chunks are being loaded.

### Testing
- Ran the production build with `npm --prefix web run build`, which completed successfully and produced separate per-panel JS/CSS chunks, confirming code-splitting worked. ✅
- Ran linter with `npm --prefix web run lint`, which failed due to existing pre-existing lint errors in unrelated files (reported by ESLint as multiple errors/warnings), so lint issues were not introduced by this change. ⚠️
- Manually inspected modified files to verify `component` fields still point at lazy-loaded components and `Suspense` fallbacks are present in both rendering entry points.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2957d77e0832ca8c55e12e82f5d17)