### PR TITLE
web: add explicit Vite manualChunks for vendor and panel domains

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -4,6 +4,40 @@ import react from '@vitejs/plugin-react'
 import svgr from 'vite-plugin-svgr'
 
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id) return;
+
+          // Keep the largest shared libraries in stable vendor chunks for cache reuse.
+          if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom/')) {
+            return 'vendor-react';
+          }
+          if (id.includes('node_modules/roslib/')) {
+            return 'vendor-ros';
+          }
+          if (id.includes('node_modules/lucide-react/')) {
+            return 'vendor-icons';
+          }
+
+          // Split major dashboard domains without over-fragmenting smaller modules.
+          if (id.includes('/src/panels/hri/')) {
+            return 'panel-hri';
+          }
+          if (id.includes('/src/panels/control/')) {
+            return 'panel-control';
+          }
+          if (id.includes('/src/panels/perception/')) {
+            return 'panel-perception';
+          }
+          if (id.includes('/src/panels/system/')) {
+            return 'panel-system';
+          }
+        },
+      },
+    },
+  },
   plugins: [
     react(),
     svgr({


### PR DESCRIPTION
### Motivation
- Provide stable, debuggable chunk names and improve cache reuse for large shared libraries by adding explicit manual chunking in the Vite build.
- Separate major dashboard domains into their own chunks to reduce duplicate code and make runtime debugging easier.

### Description
- Added `build.rollupOptions.output.manualChunks` to `web/vite.config.js` with explicit chunk rules for vendor and panel domains.
- Vendor chunks: `vendor-react` for `react`/`react-dom`, `vendor-ros` for `roslib`, and `vendor-icons` for `lucide-react`.
- Panel domain chunks: `panel-hri`, `panel-control`, `panel-perception`, and `panel-system`, using path checks under `src/panels/*` to avoid over-fragmentation.

### Testing
- Ran `cd web && npm run build` which completed successfully and produced the expected named chunks.
- Verified asset list in `dist/assets` and confirmed presence of `vendor-react`, `vendor-ros`, `vendor-icons`, and `panel-*` files.
- Checked output counts and found `8` JS files and `5` CSS files in `dist/assets`, indicating the configuration did not over-fragment requests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29802f9fc832c9d4e8e0ece1c6b18)