### PR TITLE
Add layer isolation properties to FloatingPanel styling

### DIFF
--- a/web/src/components/FloatingPanel.css
+++ b/web/src/components/FloatingPanel.css
@@ -12,6 +12,9 @@
   min-width: 240px;
   min-height: 80px;
   transition: box-shadow 0.15s;
+  isolation: isolate;
+  contain: layout paint;
+  transform: translateZ(0);
 }
 
 .fp-window:focus-within,
@@ -85,6 +88,7 @@
   overflow: auto;
   min-height: 0;
   position: relative;
+  contain: paint;
 }
 
 .fp-loading {


### PR DESCRIPTION
### Motivation
- Reduce visual flicker and improve compositing quality for the floating panel during hover, drag, and scrolling by isolating its layer and limiting cross-layer paint work.
- Encourage independent painting of the panel body to avoid repaint cascades from internal scrollable content.

### Description
- Added `isolation: isolate;` to `.fp-window` to create an isolated stacking context.
- Added `contain: layout paint;` to `.fp-window` to limit layout and paint containment to the panel.
- Added `transform: translateZ(0);` to `.fp-window` to promote it to its own compositing layer.
- Added `contain: paint;` to `.fp-body` to experiment with isolated painting for internal scrollable content.

### Testing
- Verified the CSS diff shows only the intended property insertions in `web/src/components/FloatingPanel.css` and no unintended deletions.
- Inspected the updated file contents to confirm the new properties are placed in the correct selectors and order.
- Executed repository file checks and the PR creation tool which returned the PR metadata successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29c3d13a8832ca4c33e2427ea4374)