### PR TITLE
Fix campus crawler doc_id preservation and processed URL counting

### DIFF
--- a/tools/crawler/crawl_campus.py
+++ b/tools/crawler/crawl_campus.py
@@ -429,8 +429,11 @@ def load_extra_urls(path: str) -> list[tuple]:
             parts = line.split()
             url = parts[0]
             category = parts[1] if len(parts) > 1 else "misc"
-            doc_hint = parts[2] if len(parts) > 2 else "page"
-            doc_id = normalize_doc_id(url, fallback=doc_hint)
+            doc_hint = parts[2] if len(parts) > 2 else None
+            if doc_hint:
+                doc_id = ensure_safe_doc_id(doc_hint)
+            else:
+                doc_id = normalize_doc_id(url, fallback="page")
 
             if doc_id in seen_doc_ids:
                 suffix = hashlib.sha1(url.encode("utf-8")).hexdigest()[:6]

--- a/web/src/panels/perception/CampusCrawlerPanel.jsx
+++ b/web/src/panels/perception/CampusCrawlerPanel.jsx
@@ -65,7 +65,7 @@ function CampusCrawlerPanel() {
   }
 
   function summarize(lines, finalStatus, errorMessage = '') {
-    const processedCount = lines.filter((line) => /^\[[^\]]+\]\s+/.test(line) && !line.startsWith('[WARN]')).length;
+    const processedCount = lines.filter((line) => /^\[[a-z0-9_-]+\]\s+/.test(line)).length;
     const fallbackCount = lines.filter((line) => line.includes('(raw fallback)') || line.includes('LLM refinement failed')).length;
 
     return {


### PR DESCRIPTION
### Motivation
- The `--urls` loader silently derived `doc_id` from the URL even when an explicit third token was provided, breaking the documented input format and operator-controlled IDs.
- The crawler UI summary counted any bracketed log line as a processed URL, inflating the "Processed URLs" metric because crawler output includes bracketed artifact lines like `[RAW]`, `[JSON]`, `[TXT]`, and `[REPORT]`.

### Description
- In `tools/crawler/crawl_campus.py` `load_extra_urls()`, preserve explicit third-token `doc_id` values by validating them with `ensure_safe_doc_id()` and only fall back to `normalize_doc_id()` when no explicit token is present (changed default handling from `"page"` to `None` and conditional logic).
- In `web/src/panels/perception/CampusCrawlerPanel.jsx`, tighten the processed-URL counting regex to only match per-URL header markers of the form `[{a-z0-9_-}]` so bracketed artifact lines are excluded from the count.
- Changes are limited to `tools/crawler/crawl_campus.py` and `web/src/panels/perception/CampusCrawlerPanel.jsx` and restore documented behavior and accurate UI summary counts.

### Testing
- Ran `python3 -m py_compile tools/crawler/crawl_campus.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2afdac9fc832ca884fee3f7c71c22)