### PR TITLE
Fix TopicPublisherPanel layout and trim BuildingEditor search input

### DIFF
--- a/web/src/panels/perception/BuildingEditorPanel.css
+++ b/web/src/panels/perception/BuildingEditorPanel.css
@@ -14,6 +14,15 @@
   overflow: hidden;
 }
 
+
+.km-building-list .input-search {
+  flex: 0 0 auto;
+  font-size: var(--font-size-sm);
+  line-height: 1.2;
+  padding: 3px 8px;
+  min-height: 26px;
+}
+
 .km-building-keys {
   flex: 1;
   overflow-y: auto;

--- a/web/src/panels/system/TopicPublisherPanel.css
+++ b/web/src/panels/system/TopicPublisherPanel.css
@@ -352,3 +352,145 @@
 .tp-confirm-actions button.danger:hover {
   background: color-mix(in srgb, var(--red, #d66b66) 12%, var(--bg-2));
 }
+.tp-row.tp-inline {
+  grid-template-columns: 64px 1fr;
+  align-items: center;
+}
+
+.tp-seg {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  width: fit-content;
+  background: var(--bg-2);
+}
+
+.tp-seg button {
+  border: none;
+  border-right: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-1);
+  font-size: 10px;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.tp-seg button:last-child {
+  border-right: none;
+}
+
+.tp-seg button:hover {
+  background: var(--bg-3);
+}
+
+.tp-seg button.active {
+  background: color-mix(in srgb, var(--accent, #00c8ff) 10%, var(--bg-2));
+  color: var(--accent, #00c8ff);
+}
+
+.tp-rate-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tp-rate-wrap label {
+  white-space: nowrap;
+}
+
+.tp-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.tp-publish-btn {
+  flex-shrink: 0;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text-0);
+  border-radius: var(--radius);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.tp-publish-btn:hover:not(:disabled) {
+  background: var(--bg-3);
+  border-color: var(--accent, #00c8ff);
+  color: var(--accent, #00c8ff);
+}
+
+.tp-publish-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.tp-status {
+  min-width: 0;
+  font-size: 10px;
+  color: var(--text-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tp-confirm-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 16, 0.55);
+  display: grid;
+  place-items: center;
+  z-index: 450;
+}
+
+.tp-confirm {
+  width: min(440px, calc(100vw - 24px));
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.5);
+  padding: 14px;
+}
+
+.tp-confirm h4 {
+  margin: 0 0 8px;
+  font-size: 12px;
+  letter-spacing: 0.4px;
+  color: var(--text-0);
+}
+
+.tp-confirm p {
+  margin: 0;
+  font-size: 10px;
+  line-height: 1.5;
+  color: var(--text-1);
+}
+
+.tp-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.tp-confirm-actions button {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text-0);
+  border-radius: var(--radius);
+  font-size: 10px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.tp-confirm-actions .danger {
+  border-color: var(--red, #d66b66);
+  color: var(--red, #d66b66);
+  background: color-mix(in srgb, var(--red, #d66b66) 10%, var(--bg-2));
+}

--- a/web/src/panels/system/TopicPublisherPanel.jsx
+++ b/web/src/panels/system/TopicPublisherPanel.jsx
@@ -157,10 +157,10 @@ export default function TopicPublisherPanel() {
             <button className={mode === 'periodic' ? 'active' : ''} onClick={() => setMode('periodic')}>Periodic</button>
           </div>
           {mode === 'periodic' && (
-            <>
+            <div className="tp-rate-wrap">
               <label htmlFor="tp-rate">Rate (Hz)</label>
               <input id="tp-rate" value={rateHz} onChange={(e) => setRateHz(e.target.value)} style={{ width: 80 }} />
-            </>
+            </div>
           )}
         </div>
         <div className="tp-footer">


### PR DESCRIPTION
### Motivation
- TopicPublisherPanel UI had layout mismatches causing the mode toggle, rate input and footer to misalign and the confirmation modal lacked dedicated styles.
- BuildingEditorPanel search input was visually too tall for the building list and needed a more compact height for better density.

### Description
- Wrap the periodic rate controls in a dedicated container by adding `tp-rate-wrap` in `web/src/panels/system/TopicPublisherPanel.jsx` to stabilize the mode row layout.
- Add CSS rules for `tp-inline`, `tp-seg`, `tp-rate-wrap`, `tp-footer`, `tp-publish-btn`, `tp-status`, confirmation modal/backdrop and related classes in `web/src/panels/system/TopicPublisherPanel.css` to unify styling and fix misaligned elements.
- Override `.input-search` inside the building list in `web/src/panels/perception/BuildingEditorPanel.css` to reduce font/padding/min-height and make the search input visually smaller.
- No runtime logic changes were made; changes are limited to markup structure and styles.

### Testing
- Ran `npm run build` in `web/` and the production build completed successfully.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b778ca94832cbcd5460a63c64f96)