### PR TITLE
Remove Settings from searchable panel tree

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4,7 +4,7 @@ import Sidebar            from './components/Sidebar';
 import FloatingWorkspace  from './components/FloatingWorkspace';
 import { useStore, TOPIC_META } from './core/store';
 import { fetchTopicDiagnostics, subscribeROS } from './core/ros';
-import { PANEL_TREE, findLeaf } from './panelTree';
+import { PANEL_TREE, SETTINGS_LEAF, findLeaf } from './panelTree';
 
 import './index.css';
 import './App.css';
@@ -71,19 +71,13 @@ export default function App() {
   function handlePanelSelect(id) {
     const leaf = findLeaf(PANEL_TREE, id);
     if (!leaf || leaf.placeholder) return;
-    // Settings panel receives themeMode + setter via openPanel component prop injection
     openPanel(leaf);
     if (isOverlaySidebar) setSidebarExpanded(false);
   }
 
   function handleSettingsOpen() {
-    // Find and open the settings leaf, injecting themeMode props
-    const leaf = findLeaf(PANEL_TREE, 'settings');
-    if (!leaf) return;
-    // We pass themeMode down via a wrapper component stored in the leaf
     openPanel({
-      ...leaf,
-      // The SettingsPanel reads themeMode from the leaf's extraProps
+      ...SETTINGS_LEAF,
       _themeMode: themeMode,
       _onThemeModeChange: setThemeMode,
     });

--- a/web/src/panelTree.jsx
+++ b/web/src/panelTree.jsx
@@ -50,7 +50,6 @@ import MapIcon          from './assets/icons/icon-map.svg?react';
 import CubeIcon         from './assets/icons/icon-cube.svg?react';
 import VisionIcon       from './assets/icons/icon-vision.svg?react';
 import LLMIcon          from './assets/icons/icon-llm.svg?react';
-import SettingsIcon     from './assets/icons/icon-settings.svg?react';
 
 export const PANEL_TREE = [
   {
@@ -152,18 +151,13 @@ export const PANEL_TREE = [
       },
     ],
   },
-  {
-    id: 'settings-cat', label: 'Settings', icon: <SettingsIcon />,
-    children: [
-      {
-        id: 'settings-flat', label: null,
-        children: [
-          { id: 'settings', label: 'Settings', component: SettingsPanel },
-        ],
-      },
-    ],
-  },
 ];
+
+export const SETTINGS_LEAF = {
+  id: 'settings',
+  label: 'Settings',
+  component: SettingsPanel,
+};
 
 export function flattenLeaves(tree) {
   const leaves = [];


### PR DESCRIPTION
### Motivation
- Prevent Settings from appearing in the sidebar search tree while keeping the bottom settings button as the only entry point.
- Decouple the Settings panel opening flow from tree-based lookup so `handleSettingsOpen()` does not rely on `findLeaf(..., 'settings')`.

### Description
- Removed the `settings-cat` branch from `PANEL_TREE` in `web/src/panelTree.jsx` so Settings is no longer part of the searchable tree.
- Added an exported `SETTINGS_LEAF` object in `web/src/panelTree.jsx` that contains the Settings panel metadata for use outside the tree.
- Updated `web/src/App.jsx` to import `SETTINGS_LEAF` and changed `handleSettingsOpen()` to open Settings via `SETTINGS_LEAF` (injecting `_themeMode` / `_onThemeModeChange`) instead of calling `findLeaf(..., 'settings')`.
- Left `filterTree` and `findLeaf` implementations unchanged so their behavior is preserved for the rest of the tree, and removed an unused `SettingsIcon` import from the tree file.

### Testing
- Ran `npm run lint` in `web/` which failed due to pre-existing lint issues (errors include unused prop in `Sidebar.jsx` and several `react-hooks/set-state-in-effect` problems); failures are unrelated to this change.
- Ran `npm run build` in `web/` which failed due to an unrelated unresolved import in `src/panels/hri/ConversationPanel.jsx`; build failure is unrelated to this change.
- No unit tests were added or changed for this PR; manual behavior validation was performed by inspecting modified files to ensure `Settings` is no longer present in `PANEL_TREE` and `handleSettingsOpen()` now uses `SETTINGS_LEAF`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c413608528832cb30b567bd3d68c01)