### PR TITLE
Move Settings into main tab, add activeMainView state, and remove floating settings panel

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2,9 +2,10 @@ import { useState, useEffect } from 'react';
 import Header             from './components/Header';
 import Sidebar            from './components/Sidebar';
 import FloatingWorkspace  from './components/FloatingWorkspace';
+import SettingsTab        from './tabs/SettingsTab';
 import { useStore, TOPIC_META } from './core/store';
 import { fetchTopicDiagnostics, subscribeROS } from './core/ros';
-import { PANEL_TREE, SETTINGS_LEAF, findLeaf } from './panelTree';
+import { PANEL_TREE, findLeaf } from './panelTree';
 
 import './index.css';
 import './App.css';
@@ -27,6 +28,8 @@ export default function App() {
   const handleROSMessage = useStore(s => s.handleROSMessage);
   const setTopicMeta     = useStore(s => s.setTopicMeta);
   const openPanel        = useStore(s => s.openPanel);
+  const activeMainView   = useStore(s => s.activeMainView);
+  const setActiveMainView = useStore(s => s.setActiveMainView);
 
   useEffect(() => {
     if (!connected) return;
@@ -72,15 +75,12 @@ export default function App() {
     const leaf = findLeaf(PANEL_TREE, id);
     if (!leaf || leaf.placeholder) return;
     openPanel(leaf);
+    setActiveMainView('workspace');
     if (isOverlaySidebar) setSidebarExpanded(false);
   }
 
   function handleSettingsOpen() {
-    openPanel({
-      ...SETTINGS_LEAF,
-      _themeMode: themeMode,
-      _onThemeModeChange: setThemeMode,
-    });
+    setActiveMainView('settings');
     if (isOverlaySidebar) setSidebarExpanded(false);
   }
 
@@ -117,7 +117,11 @@ export default function App() {
       </div>
 
       <main className="app-main">
-        <FloatingWorkspace isMobile={isMobile} themeMode={themeMode} onThemeModeChange={setThemeMode} />
+        {activeMainView === 'settings' ? (
+          <SettingsTab themeMode={themeMode} onThemeModeChange={setThemeMode} />
+        ) : (
+          <FloatingWorkspace isMobile={isMobile} />
+        )}
       </main>
     </div>
   );

--- a/web/src/components/FloatingPanel.jsx
+++ b/web/src/components/FloatingPanel.jsx
@@ -50,7 +50,7 @@ function useResizable({ w, h, onResize }) {
   return { onResizeStart };
 }
 
-export default function FloatingPanel({ panel, themeMode, onThemeModeChange }) {
+export default function FloatingPanel({ panel }) {
   const { id, label, component: Component, x, y, w, h, minimized, zIndex } = panel;
 
   const closePanel    = useStore(s => s.closePanel);
@@ -75,9 +75,6 @@ export default function FloatingPanel({ panel, themeMode, onThemeModeChange }) {
     if (!minimized) heightBeforeMinimize.current = h;
     minimizePanel(id);
   }
-
-  // Settings panel gets theme props injected
-  const isSettings = id === 'settings';
 
   return (
     <div
@@ -116,10 +113,7 @@ export default function FloatingPanel({ panel, themeMode, onThemeModeChange }) {
       {!minimized && (
         <div className="fp-body">
           <Suspense fallback={<div className="fp-loading">Loading panel…</div>}>
-            {isSettings
-              ? <Component themeMode={themeMode} onThemeModeChange={onThemeModeChange} />
-              : <Component />
-            }
+            <Component />
           </Suspense>
         </div>
       )}

--- a/web/src/components/FloatingWorkspace.jsx
+++ b/web/src/components/FloatingWorkspace.jsx
@@ -11,7 +11,7 @@ import FloatingPanel from './FloatingPanel';
 import MobileStack   from './MobileStack';
 import './FloatingWorkspace.css';
 
-export default function FloatingWorkspace({ isMobile, themeMode, onThemeModeChange }) {
+export default function FloatingWorkspace({ isMobile }) {
   const openPanels = useStore(s => s.openPanels);
 
   if (openPanels.length === 0) {
@@ -23,7 +23,7 @@ export default function FloatingWorkspace({ isMobile, themeMode, onThemeModeChan
   }
 
   if (isMobile) {
-    return <MobileStack panels={openPanels} themeMode={themeMode} onThemeModeChange={onThemeModeChange} />;
+    return <MobileStack panels={openPanels} />;
   }
 
   return (
@@ -32,8 +32,6 @@ export default function FloatingWorkspace({ isMobile, themeMode, onThemeModeChan
         <FloatingPanel
           key={panel.id}
           panel={panel}
-          themeMode={themeMode}
-          onThemeModeChange={onThemeModeChange}
         />
       ))}
     </div>

--- a/web/src/components/Header.jsx
+++ b/web/src/components/Header.jsx
@@ -102,7 +102,7 @@ export default function Header({ onLogoClick, themeMode, sidebarExpanded }) {
       <div className="hdr-spacer" />
 
       <div className="hdr-conn">
-        {/* URL input — synced with SettingsPanel but kept here for quick access */}
+        {/* URL input — synced with Settings tab but kept here for quick access */}
         <input
           className="hdr-url"
           value={urlInput}

--- a/web/src/core/floatingPanels.js
+++ b/web/src/core/floatingPanels.js
@@ -44,7 +44,6 @@ const PANEL_SIZES = {
   'sys-metrics':        [360, 340],
   'vision-test':        [480, 460],
   'llm-inject':         [420, 250],
-  'settings': [600, 300],
 };
 
 let zCounter = 10;

--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -343,6 +343,10 @@ export const useStore = create((set, get) => ({
     set({ wsUrl: v });
   },
 
+  // ── Main view (workspace/settings) ─────────────────────────────────────
+  activeMainView: 'workspace',
+  setActiveMainView: (view) => set({ activeMainView: view }),
+
   // ── Cube Sim ────────────────────────────────────────────────────────────
   cubeState: createSolvedCube(),
   cubeMoveHistory: [],

--- a/web/src/panelTree.jsx
+++ b/web/src/panelTree.jsx
@@ -34,8 +34,6 @@ const EventLogPanel = lazy(() => import('./panels/system/EventLogPanel'));
 const TopicPublisherPanel = lazy(() => import('./panels/system/TopicPublisherPanel'));
 const DeployStatusPanel = lazy(() => import('./panels/system/DeployStatusPanel'));
 
-const SettingsPanel = lazy(() => import('./panels/system/SettingsPanel'));
-
 import HriIcon        from './assets/icons/icon-hri.svg?react';
 import ControlIcon    from './assets/icons/icon-control.svg?react';
 import SystemIcon     from './assets/icons/icon-system.svg?react';
@@ -153,11 +151,6 @@ export const PANEL_TREE = [
   },
 ];
 
-export const SETTINGS_LEAF = {
-  id: 'settings',
-  label: 'Settings',
-  component: SettingsPanel,
-};
 
 export function flattenLeaves(tree) {
   const leaves = [];

--- a/web/src/tabs/SettingsTab.css
+++ b/web/src/tabs/SettingsTab.css
@@ -1,5 +1,3 @@
-/* ── SettingsPanel.css ─────────────────────────────────────────────────────── */
-
 .sp-root {
   display: flex;
   flex-direction: column;
@@ -8,8 +6,6 @@
   overflow-y: auto;
   padding-bottom: var(--space-4);
 }
-
-/* ── Section ─────────────────────────────────────────────────────────────── */
 
 .sp-section {
   border-bottom: 1px solid var(--border-default);
@@ -36,8 +32,6 @@
   flex-direction: column;
   gap: var(--space-3);
 }
-
-/* ── Row ─────────────────────────────────────────────────────────────────── */
 
 .sp-row {
   display: flex;
@@ -69,8 +63,6 @@
 .sp-row-control {
   flex-shrink: 0;
 }
-
-/* ── Segmented control ───────────────────────────────────────────────────── */
 
 .sp-seg {
   display: inline-flex;
@@ -108,8 +100,6 @@
   color: var(--color-info);
   font-weight: 600;
 }
-
-/* ── WebSocket row ───────────────────────────────────────────────────────── */
 
 .sp-ws-row {
   display: flex;
@@ -164,8 +154,6 @@
   opacity: 0.4;
   cursor: not-allowed;
 }
-
-/* ── Responsive ──────────────────────────────────────────────────────────── */
 
 @media (max-width: 480px) {
   .sp-row {

--- a/web/src/tabs/SettingsTab.jsx
+++ b/web/src/tabs/SettingsTab.jsx
@@ -1,15 +1,7 @@
-/**
- * panels/system/SettingsPanel.jsx
- * Unified settings panel — theme, language, connection.
- * Moved from: Header theme selector.
- */
-
-import { useEffect, useState } from 'react';
-import { useStore } from '../../core/store';
-import { useI18n, detectBrowserLang, LANG_LABELS } from '../../core/i18n';
-import './SettingsPanel.css';
-
-// ── Section wrapper ───────────────────────────────────────────────────────────
+import { useState } from 'react';
+import { useStore } from '../core/store';
+import { useI18n, detectBrowserLang, LANG_LABELS } from '../core/i18n';
+import './SettingsTab.css';
 
 function Section({ title, children }) {
   return (
@@ -19,8 +11,6 @@ function Section({ title, children }) {
     </div>
   );
 }
-
-// ── Row ───────────────────────────────────────────────────────────────────────
 
 function Row({ label, hint, children }) {
   return (
@@ -33,8 +23,6 @@ function Row({ label, hint, children }) {
     </div>
   );
 }
-
-// ── Segmented control ─────────────────────────────────────────────────────────
 
 function Seg({ options, value, onChange }) {
   return (
@@ -52,9 +40,7 @@ function Seg({ options, value, onChange }) {
   );
 }
 
-// ── Main panel ────────────────────────────────────────────────────────────────
-
-export default function SettingsPanel({ themeMode, onThemeModeChange }) {
+export default function SettingsTab({ themeMode, onThemeModeChange }) {
   const { t, langPref } = useI18n();
   const setLangPref = useStore(s => s.setLangPref);
   const wsUrl       = useStore(s => s.wsUrl);
@@ -64,10 +50,6 @@ export default function SettingsPanel({ themeMode, onThemeModeChange }) {
   const [wsInput, setWsInput] = useState(wsUrl);
   const detectedLang = detectBrowserLang();
 
-  // Keep wsInput in sync when store changes externally
-  useEffect(() => {
-    if (!connected) setWsInput(wsUrl);
-  }, [wsUrl, connected]);
 
   function handleWsSave() {
     setWsUrl(wsInput.trim());
@@ -87,15 +69,12 @@ export default function SettingsPanel({ themeMode, onThemeModeChange }) {
 
   return (
     <div className="sp-root">
-
-      {/* ── Appearance ── */}
       <Section title={t('settings.section.appearance')}>
         <Row label={t('settings.theme.label')}>
           <Seg options={themeOptions} value={themeMode} onChange={onThemeModeChange} />
         </Row>
       </Section>
 
-      {/* ── Language ── */}
       <Section title={t('settings.section.language')}>
         <Row
           label={t('settings.lang.label')}
@@ -107,7 +86,6 @@ export default function SettingsPanel({ themeMode, onThemeModeChange }) {
         </Row>
       </Section>
 
-      {/* ── Connection ── */}
       <Section title={t('settings.section.connection')}>
         <Row label={t('settings.ws.label')} hint={t('settings.ws.hint')}>
           <div className="sp-ws-row">
@@ -130,9 +108,6 @@ export default function SettingsPanel({ themeMode, onThemeModeChange }) {
           </div>
         </Row>
       </Section>
-
     </div>
   );
 }
-
-export { SettingsPanel };


### PR DESCRIPTION
### Motivation
- Consolidate settings into a top-level tab instead of a floating panel to simplify UI flow and avoid injecting theme props into individual floating panels.
- Simplify floating panel handling by removing special-casing for the settings panel and reduce prop threading for `themeMode`.
- Provide a simple main-view toggle (workspace ↔ settings) in the global store for clearer navigation state.

### Description
- Renamed and moved `SettingsPanel` to `tabs/SettingsTab.jsx` with corresponding stylesheet `tabs/SettingsTab.css`, and updated imports to use `SettingsTab`.
- Added `activeMainView` and `setActiveMainView` to the store and wired `App.jsx` to switch the main area between `FloatingWorkspace` and `SettingsTab` using `activeMainView`.
- Removed the `SETTINGS_LEAF` entry and settings leaf export from `panelTree.jsx` and stopped opening settings as a floating panel in `App.jsx` by calling `setActiveMainView('settings')` instead.
- Stopped passing `themeMode` and `onThemeModeChange` into `FloatingWorkspace` and `FloatingPanel`, and removed the `settings` special-case in `FloatingPanel` so all panels are treated uniformly.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c418312e10832cbd2a6993be00275e)