### PR TITLE
Fix Settings tab sidebar toggle regression and add Settings header controls

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -84,6 +84,10 @@ export default function App() {
     if (isOverlaySidebar) setSidebarExpanded(false);
   }
 
+  function handleSettingsClose() {
+    setActiveMainView('workspace');
+  }
+
   return (
     <div className={`app ${sidebarExpanded ? 'sb-expanded' : ''} ${isOverlaySidebar ? 'sb-overlay' : ''}`}>
       <div className="app-sidebar">
@@ -118,7 +122,11 @@ export default function App() {
 
       <main className="app-main">
         {activeMainView === 'settings' ? (
-          <SettingsTab themeMode={themeMode} onThemeModeChange={setThemeMode} />
+          <SettingsTab
+            themeMode={themeMode}
+            onThemeModeChange={setThemeMode}
+            onClose={handleSettingsClose}
+          />
         ) : (
           <FloatingWorkspace isMobile={isMobile} />
         )}

--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -304,7 +304,6 @@ export default function Sidebar({
           className="sb-settings-btn"
           onClick={() => {
             onSettingsOpen?.();
-            if (!expanded) onExpand();
           }}
           title={!expanded ? t('panel.settings') : undefined}
         >

--- a/web/src/tabs/SettingsTab.css
+++ b/web/src/tabs/SettingsTab.css
@@ -7,6 +7,44 @@
   padding-bottom: var(--space-4);
 }
 
+.sp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.sp-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  color: var(--text-primary);
+}
+
+.sp-close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.sp-close-btn:hover {
+  background: var(--red-dim);
+  color: var(--red);
+}
+
+.sp-close-btn svg {
+  width: 12px;
+  height: 12px;
+}
+
 .sp-section {
   border-bottom: 1px solid var(--border-default);
   padding: var(--space-3) var(--space-4);

--- a/web/src/tabs/SettingsTab.jsx
+++ b/web/src/tabs/SettingsTab.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useStore } from '../core/store';
 import { useI18n, detectBrowserLang, LANG_LABELS } from '../core/i18n';
+import CloseIcon from '../assets/icons/icon-close.svg?react';
 import './SettingsTab.css';
 
 function Section({ title, children }) {
@@ -40,7 +41,7 @@ function Seg({ options, value, onChange }) {
   );
 }
 
-export default function SettingsTab({ themeMode, onThemeModeChange }) {
+export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
   const { t, langPref } = useI18n();
   const setLangPref = useStore(s => s.setLangPref);
   const wsUrl       = useStore(s => s.wsUrl);
@@ -69,6 +70,13 @@ export default function SettingsTab({ themeMode, onThemeModeChange }) {
 
   return (
     <div className="sp-root">
+      <header className="sp-header">
+        <h2 className="sp-title">{t('settings.title')}</h2>
+        <button className="sp-close-btn" onClick={onClose} aria-label={t('sidebar.close')}>
+          <CloseIcon />
+        </button>
+      </header>
+
       <Section title={t('settings.section.appearance')}>
         <Row label={t('settings.theme.label')}>
           <Seg options={themeOptions} value={themeMode} onChange={onThemeModeChange} />


### PR DESCRIPTION
## Summary
- fixed a regression where clicking the Settings icon from a collapsed sidebar expanded the sidebar
- added a Settings tab header with a localized `Settings` title
- added a top-right close button in Settings to return to the workspace view

## Changes
- `web/src/components/Sidebar.jsx`
  - removed the `onExpand()` call from the Settings button click handler so opening Settings no longer forces sidebar expansion
- `web/src/App.jsx`
  - added `handleSettingsClose()` to switch `activeMainView` back to `workspace`
  - passed `onClose` into `SettingsTab`
- `web/src/tabs/SettingsTab.jsx`
  - added header markup (`sp-header`, `sp-title`, close button)
  - wired close button to new `onClose` prop
- `web/src/tabs/SettingsTab.css`
  - added styles for the Settings header and close button

## Validation
- static inspection of sidebar/settings interaction flow and prop wiring
- no test execution performed in this environment

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c41cc677c8832c8a986fbd37ffd0ec)