### PR TITLE
feat(sidebar): support bilingual multi-key panel search

### DIFF
--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useStore } from '../core/store';
-import { useI18n } from '../core/i18n';
+import { translateKeyBoth, useI18n } from '../core/i18n';
 import { filterTree } from '../panelTree';
 import DoriLogoIconMono  from '../assets/logo/logo-icon-mono.svg?react';
 import DoriLogoIconColor from '../assets/logo/logo-icon-color.svg?react';
@@ -178,16 +178,41 @@ export default function Sidebar({
   // Build a translated version of the tree for display
   // The tree nodes themselves carry their own labels; we remap them with i18n keys.
   const translatedTree = useMemo(() => {
+    function getNodeI18nKey(node) {
+      return (node.component || node.placeholder)
+        ? `panel.${node.id}`
+        : `sidebar.${node.id.replace(/-/g, '.')}`;
+    }
+
+    function buildSearchTexts(currentLabel, originalLabel, i18nKey) {
+      const { ko, en } = translateKeyBoth(i18nKey, originalLabel || currentLabel || '');
+      return [
+        currentLabel,
+        originalLabel,
+        ko,
+        en,
+      ].filter(Boolean);
+    }
+
     function translateNode(node) {
+      const i18nKey = getNodeI18nKey(node);
+      const originalLabel = node.label;
       if (node.component || node.placeholder) {
-        return { ...node, label: t(`panel.${node.id}`) || node.label, _soonLabel: t('sidebar.soon') };
+        const translatedLabel = t(i18nKey) || originalLabel;
+        return {
+          ...node,
+          label: translatedLabel,
+          _soonLabel: t('sidebar.soon'),
+          searchTexts: buildSearchTexts(translatedLabel, originalLabel, i18nKey),
+        };
       }
       // Category or subcategory — try specific i18n key, fall back to original label
-      const i18nKey = `sidebar.${node.id.replace(/-/g, '.')}`;
-      const translatedLabel = t(i18nKey) !== i18nKey ? t(i18nKey) : node.label;
+      const translatedByKey = t(i18nKey);
+      const translatedLabel = translatedByKey !== i18nKey ? translatedByKey : originalLabel;
       return {
         ...node,
         label: translatedLabel,
+        searchTexts: buildSearchTexts(translatedLabel, originalLabel, i18nKey),
         children: node.children ? node.children.map(translateNode) : undefined,
       };
     }

--- a/web/src/core/i18n.js
+++ b/web/src/core/i18n.js
@@ -254,6 +254,21 @@ export function translateKey(key, effectiveLang) {
 }
 
 /**
+ * Get both Korean and English translations for a key.
+ * If key is missing in both languages, both fields return fallback text.
+ */
+export function translateKeyBoth(key, fallback = '') {
+  const en = translateKey(key, 'en');
+  const ko = translateKey(key, 'ko');
+  const hasAnyTranslation = en !== key || ko !== key;
+  if (!hasAnyTranslation) return { en: fallback, ko: fallback };
+  return {
+    en: en === key ? fallback : en,
+    ko: ko === key ? fallback : ko,
+  };
+}
+
+/**
  * React hook — returns a `t(key)` function that re-renders when language changes.
  */
 export function useI18n() {

--- a/web/src/panelTree.jsx
+++ b/web/src/panelTree.jsx
@@ -168,14 +168,22 @@ export function findLeaf(tree, id) {
   return flattenLeaves(tree).find(l => l.id === id) ?? null;
 }
 
-export function filterTree(tree, query) {
+export function filterTree(tree, query, getSearchTexts = null) {
   if (!query.trim()) return tree;
   const q = query.trim().toLowerCase();
+  const resolveSearchTexts = (node) => {
+    const customTexts = getSearchTexts?.(node);
+    const sourceTexts = customTexts ?? node.searchTexts ?? [node.label];
+    return sourceTexts
+      .filter(Boolean)
+      .map(text => String(text).trim().toLowerCase())
+      .filter(Boolean);
+  };
   function filterNodes(nodes) {
     const result = [];
     for (const node of nodes) {
       if (node.component || node.placeholder) {
-        if (node.label.toLowerCase().includes(q)) result.push(node);
+        if (resolveSearchTexts(node).some(text => text.includes(q))) result.push(node);
       } else if (node.children) {
         const fc = filterNodes(node.children);
         if (fc.length > 0) result.push({ ...node, children: fc });


### PR DESCRIPTION
### Motivation
- Improve sidebar search to match panels by multiple searchable texts instead of a single label to allow matching by translated and original names.
- Include both Korean and English variants in search texts so searching works regardless of UI language.

### Description
- Extended `filterTree` (`web/src/panelTree.jsx`) to `filterTree(tree, query, getSearchTexts = null)` and normalize inputs with `trim().toLowerCase()` while matching using `some(text => text.includes(q))`.
- Added `resolveSearchTexts` logic to use a caller `getSearchTexts(node)`, or `node.searchTexts`, or fall back to `[node.label]` for each leaf/placeholder.
- Updated sidebar translation pipeline (`web/src/components/Sidebar.jsx`) to attach `searchTexts` to every node (category/subcategory/leaf) containing current display label, original source label, and both `ko`/`en` translations resolved from i18n keys.
- Added `translateKeyBoth` helper in `web/src/core/i18n.js` to fetch both Korean and English translations for a key and reused existing `translateKey` to populate bilingual search entries.

### Testing
- Ran `npm run build` in `web/` and the production build completed successfully. ✅
- Ran `npm run lint` in `web/` and it reported existing unrelated lint errors in other files; no new lint categories were introduced by these changes. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c423f007e4832cb935921776135f9c)