### PR TITLE
Add language switching for hint text and textarea placeholders

### DIFF
--- a/web/src/core/i18n.js
+++ b/web/src/core/i18n.js
@@ -142,6 +142,15 @@ const TRANSLATIONS = {
     'settings.section.connection': 'Connection',
     'settings.ws.label': 'ROS WebSocket URL',
     'settings.ws.hint': 'Default: ws://[Robot IP]:9090',
+
+    // HRI / Perception panel texts
+    'panel.tts.placeholder': 'Text for robot speech (e.g. Hello, I am DORI.)',
+    'panel.stt.placeholder': 'Enter a test utterance (e.g. Where is the library?)',
+    'panel.stt.hint': 'Recorded audio is published to /dori/debug/audio_blob. Subscribe on Jetson and pass to Whisper for end-to-end STT testing.',
+    'panel.wakeword.hint': 'HRI Manager only reacts in IDLE. You can test the LISTENING → RESPONDING → IDLE cycle.',
+    'panel.llm.query.placeholder': 'Question (e.g. Where is the student cafeteria?)',
+    'panel.llm.location.placeholder': 'e.g. In front of Building E7',
+    'panel.vision.hint': 'Frames are published as sensor_msgs/msg/CompressedImage. If person detection, gesture, or expression nodes subscribe, you can run real-time vision tests.',
   },
 
   ko: {
@@ -238,6 +247,15 @@ const TRANSLATIONS = {
     'settings.section.connection': '연결',
     'settings.ws.label': 'ROS WebSocket URL',
     'settings.ws.hint': '기본값: ws://[로봇 IP]:9090',
+
+    // HRI / Perception panel texts
+    'panel.tts.placeholder': '로봇이 말할 텍스트 (예: 안녕하세요, 도리입니다.)',
+    'panel.stt.placeholder': '테스트할 발화를 입력하세요 (예: 도서관 어디야)',
+    'panel.stt.hint': '녹음된 오디오는 /dori/debug/audio_blob으로 publish됩니다. Jetson 측에서 이 토픽을 구독해 Whisper로 전달하면 실제 STT 테스트가 가능합니다.',
+    'panel.wakeword.hint': 'HRI Manager가 IDLE일 때만 반응합니다. LISTENING → RESPONDING → IDLE 사이클을 테스트할 수 있습니다.',
+    'panel.llm.query.placeholder': '질문 (예: 학생식당 어디에 있어요?)',
+    'panel.llm.location.placeholder': '예: E7 건물 앞',
+    'panel.vision.hint': '프레임은 sensor_msgs/msg/CompressedImage로 publish됩니다. person_detection, gesture, expression 노드가 구독 중이라면 실시간 비전 테스트가 가능합니다.',
   },
 };
 

--- a/web/src/panels/hri/STTPanel.jsx
+++ b/web/src/panels/hri/STTPanel.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Mic, MicOff } from 'lucide-react';
 import { LOG_TAGS, useStore } from '../../core/store';
 import { publishROS } from '../../core/ros';
+import { useI18n } from '../../core/i18n';
 import './STTPanel.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -35,6 +36,7 @@ function SectionLabel({ children }) {
 // ── STT Panel ─────────────────────────────────────────────────────────────────
 
 function STTPanel() {
+  const { t } = useI18n();
   const connected  = useStore(s => s.connected);
   const isDemoMode = useStore(s => s.isDemoMode);
   const addLog     = useStore(s => s.addLog);
@@ -138,7 +140,7 @@ function STTPanel() {
       <textarea
         className="input-text"
         rows={2}
-        placeholder="테스트할 발화를 입력하세요 (예: 도서관 어디야)"
+        placeholder={t('panel.stt.placeholder')}
         value={text}
         onChange={e => setText(e.target.value)}
         onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleTextInject(); } }}
@@ -201,8 +203,7 @@ function STTPanel() {
       </div>
 
       <p className="hint-text">
-        녹음된 오디오는 <code>/dori/debug/audio_blob</code>으로 publish됩니다.
-        Jetson 측에서 이 토픽을 구독해 Whisper로 전달하면 실제 STT 테스트가 가능합니다.
+        {t('panel.stt.hint')}
       </p>
     </div>
   );

--- a/web/src/panels/hri/TTSInjectPanel.jsx
+++ b/web/src/panels/hri/TTSInjectPanel.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { LOG_TAGS, useStore } from '../../core/store';
 import { publishROS } from '../../core/ros';
+import { useI18n } from '../../core/i18n';
 
 function pub(topic, msgType, data) {
   try {
@@ -17,6 +18,7 @@ function SectionLabel({ children }) {
 }
 
 function TTSInjectPanel() {
+  const { t } = useI18n();
   const connected = useStore(s => s.connected);
   const isDemoMode = useStore(s => s.isDemoMode);
   const addLog = useStore(s => s.addLog);
@@ -39,7 +41,7 @@ function TTSInjectPanel() {
       <textarea
         className="input-text"
         rows={3}
-        placeholder="로봇이 말할 텍스트 (예: 안녕하세요, 도리입니다.)"
+        placeholder={t('panel.tts.placeholder')}
         value={ttsText}
         onChange={e => setTtsText(e.target.value)}
         onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleTTS(); } }}

--- a/web/src/panels/hri/WakeWordPanel.jsx
+++ b/web/src/panels/hri/WakeWordPanel.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Zap } from 'lucide-react';
 import { LOG_TAGS, useStore } from '../../core/store';
 import { publishROS } from '../../core/ros';
+import { useI18n } from '../../core/i18n';
 import './WakeWordPanel.css';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -26,6 +27,7 @@ function SectionLabel({ children }) {
 // ── Wake Word Panel ───────────────────────────────────────────────────────────
 
 function WakeWordPanel() {
+  const { t } = useI18n();
   const connected  = useStore(s => s.connected);
   const isDemoMode = useStore(s => s.isDemoMode);
   const hriState   = useStore(s => s.hriState);
@@ -57,7 +59,7 @@ function WakeWordPanel() {
         {lastTs && <span className="hint-inline">fired at {lastTs}</span>}
       </div>
       <p className="hint-text">
-        HRI Manager가 IDLE일 때만 반응합니다. LISTENING → RESPONDING → IDLE 사이클을 테스트할 수 있습니다.
+        {t('panel.wakeword.hint')}
       </p>
     </div>
   );

--- a/web/src/panels/perception/LLMInjectPanel.jsx
+++ b/web/src/panels/perception/LLMInjectPanel.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { LOG_TAGS, useStore } from '../../core/store';
 import { publishROS } from '../../core/ros';
+import { useI18n } from '../../core/i18n';
 
 function pub(topic, msgType, data) {
   try {
@@ -17,6 +18,7 @@ function SectionLabel({ children }) {
 }
 
 function LLMInjectPanel() {
+  const { t } = useI18n();
   const connected = useStore(s => s.connected);
   const isDemoMode = useStore(s => s.isDemoMode);
   const addLog = useStore(s => s.addLog);
@@ -48,7 +50,7 @@ function LLMInjectPanel() {
       <textarea
         className="input-text"
         rows={2}
-        placeholder="질문 (예: 학생식당 어디에 있어요?)"
+        placeholder={t('panel.llm.query.placeholder')}
         value={llmQuery}
         onChange={e => setLlmQuery(e.target.value)}
         onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleLLM(); } }}
@@ -58,7 +60,7 @@ function LLMInjectPanel() {
         <input
           className="input input-full"
           type="text"
-          placeholder="예: E7 건물 앞"
+          placeholder={t('panel.llm.location.placeholder')}
           value={locCtx}
           onChange={e => setLocCtx(e.target.value)}
         />

--- a/web/src/panels/perception/VisionPanel.jsx
+++ b/web/src/panels/perception/VisionPanel.jsx
@@ -4,6 +4,7 @@ import {
 } from 'lucide-react';
 import { LOG_TAGS, useStore } from '../../core/store';
 import { publishROS } from '../../core/ros';
+import { useI18n } from '../../core/i18n';
 import './VisionPanel.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -39,6 +40,7 @@ function SectionLabel({ children }) {
 // ── Vision Test Panel ─────────────────────────────────────────────────────────
 
 function VisionPanel() {
+  const { t } = useI18n();
   const connected   = useStore(s => s.connected);
   const isDemoMode  = useStore(s => s.isDemoMode);
   const addLog      = useStore(s => s.addLog);
@@ -187,8 +189,7 @@ function VisionPanel() {
       </div>
 
       <p className="hint-text">
-        프레임은 <code>sensor_msgs/msg/CompressedImage</code>로 publish됩니다.
-        person_detection, gesture, expression 노드가 구독 중이라면 실시간 비전 테스트가 가능합니다.
+        {t('panel.vision.hint')}
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- Added new i18n keys in `web/src/core/i18n.js` for HRI/Perception hint-text copy and textarea placeholders.
- Wired `useI18n()` into the affected panels so these strings now react to Korean/English language changes.

## Updated panels
- `web/src/panels/hri/TTSInjectPanel.jsx`
- `web/src/panels/hri/STTPanel.jsx`
- `web/src/panels/hri/WakeWordPanel.jsx`
- `web/src/panels/perception/LLMInjectPanel.jsx`
- `web/src/panels/perception/VisionPanel.jsx`

## Notes
- This focuses on the currently hardcoded textarea placeholders and `hint-text` blocks reported in HRI/Perception panels.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42660b1e0832cb225aeec17ed829a)