### PR TITLE
Unify repository root detection and fix dashboard builder path

### DIFF
--- a/ros2_ws/src/bringup/launch/robot.launch.py
+++ b/ros2_ws/src/bringup/launch/robot.launch.py
@@ -17,6 +17,15 @@ from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
+try:
+    from llm_pkg.paths import is_repo_root
+except Exception:
+    def is_repo_root(parent):
+        has_readme = (parent / 'README.md').exists()
+        has_ros2_src = (parent / 'ros2_ws' / 'src').is_dir()
+        has_git = (parent / '.git').exists()
+        return has_readme and (has_ros2_src or has_git)
+
 
 def _resolve_path(share_relative: str, pkg_name: str, data_relative: str) -> str:
     """Resolve an asset path from installed share first, then repository root."""
@@ -31,7 +40,7 @@ def _resolve_path(share_relative: str, pkg_name: str, data_relative: str) -> str
 
     this_file = pathlib.Path(__file__).resolve()
     for parent in this_file.parents:
-        if (parent / 'src').is_dir() and (parent / 'README.md').exists():
+        if is_repo_root(parent):
             candidate = parent / data_relative
             if candidate.exists():
                 return str(candidate)

--- a/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -37,12 +37,28 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+try:
+    from llm_pkg.paths import find_repo_root as _shared_find_repo_root
+except Exception:
+    _shared_find_repo_root = None
+
 # ── Path resolution ────────────────────────────────────────────────────────────
 
 def find_repo_root(start: Path) -> Path:
-    """Walk up from start until we find the repo root (contains README.md + src/)."""
+    """Walk up from start until we find the repo root.
+
+    Root markers:
+      - ros2_ws/src directory + README.md
+      - OR .git + README.md
+    """
+    if _shared_find_repo_root is not None:
+        return _shared_find_repo_root(start)
+
     for parent in [start, *start.parents]:
-        if (parent / 'src').is_dir() and (parent / 'README.md').exists():
+        has_readme = (parent / 'README.md').exists()
+        has_ros2_src = (parent / 'ros2_ws' / 'src').is_dir()
+        has_git = (parent / '.git').exists()
+        if has_readme and (has_ros2_src or has_git):
             return parent
     return start  # fallback
 
@@ -57,7 +73,7 @@ args, _ = parser_arg.parse_known_args()
 
 REPO_ROOT   = Path(args.repo_root)
 PARSER_SCRIPT  = REPO_ROOT / 'tools' / 'parser' / 'parse_cafeteria_menu.py'
-BUILDER_SCRIPT = REPO_ROOT / 'src' / 'llm_pkg' / 'llm_pkg' / 'build_index.py'
+BUILDER_SCRIPT = REPO_ROOT / 'ros2_ws' / 'src' / 'llm_pkg' / 'llm_pkg' / 'build_index.py'
 CRAWLER_SCRIPT = REPO_ROOT / 'tools' / 'crawler' / 'crawl_campus.py'
 PROCESSED_DIR  = REPO_ROOT / 'data' / 'campus' / 'processed'
 INDEXED_DIR    = REPO_ROOT / 'data' / 'campus' / 'indexed'

--- a/ros2_ws/src/llm_pkg/llm_pkg/paths.py
+++ b/ros2_ws/src/llm_pkg/llm_pkg/paths.py
@@ -13,11 +13,24 @@ Usage:
 from pathlib import Path
 
 
+def is_repo_root(parent: Path) -> bool:
+    """Return True when parent matches repository-root markers."""
+    has_readme = (parent / 'README.md').exists()
+    has_ros2_src = (parent / 'ros2_ws' / 'src').is_dir()
+    has_git = (parent / '.git').exists()
+    return has_readme and (has_ros2_src or has_git)
+
+
 def find_repo_root(start: Path = None) -> Path:
-    """Walk up from start until we find the repo root (contains README.md + src/)."""
+    """Walk up from start until we find the repo root.
+
+    Root markers:
+      - ros2_ws/src directory + README.md
+      - OR .git + README.md
+    """
     start = start or Path(__file__).resolve().parent
     for parent in [start, *start.parents]:
-        if (parent / 'src').is_dir() and (parent / 'README.md').exists():
+        if is_repo_root(parent):
             return parent
     return start
 
@@ -70,6 +83,5 @@ def get_rag_index_dir() -> Path:
     Dev:  data/campus/indexed/
     """
     return find_repo_root() / 'data' / 'campus' / 'indexed'
-
 
 


### PR DESCRIPTION
### Motivation
- 여러 위치에서 서로 다른 루트 탐지 로직이 중복되어 유지보수성이 떨어져 이를 공통 규칙으로 통일하고자 했습니다.
- 루트 판별을 `ros2_ws/src + README.md` 또는 `.git + README.md` 중 하나로 확장해 다양한 개발/배포 트리를 지원하도록 했습니다.
- `dashboard`에서 조합하는 스크립트/데이터 경로가 실제 리포지토리 트리와 일치하는지 점검하고 잘못된 경로를 수정했습니다.

### Description
- `llm_pkg/llm_pkg/paths.py`에 `is_repo_root(parent: Path) -> bool` 헬퍼를 추가하고 `find_repo_root()`가 이를 사용하도록 변경했습니다.
- `dashboard_pkg/dashboard_pkg/knowledge_api.py`의 `find_repo_root()`가 가능하면 `llm_pkg.paths.find_repo_root`를 재사용하도록 리팩터링하고, 사용할 수 없을 때 동일 규칙의 로컬 fallback을 유지하도록 변경했습니다.
- `knowledge_api.py`에서 잘못되어 있던 `BUILDER_SCRIPT` 경로를 실제 트리 위치인 `ros2_ws/src/llm_pkg/llm_pkg/build_index.py`로 수정했습니다.
- `bringup/launch/robot.launch.py`의 `_resolve_path` 루프에서 동일한 루트 판별 규칙을 사용하도록 `is_repo_root()`를 재사용(불가 시 로컬 fallback)하도록 변경했습니다.

### Testing
- `python3 -m py_compile ros2_ws/src/llm_pkg/llm_pkg/paths.py ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py ros2_ws/src/bringup/launch/robot.launch.py`를 실행해 문법 검사를 수행했고 성공했습니다.
- 리포지토리 레이아웃 관련 파일 존재 여부를 `test -f tools/parser/parse_cafeteria_menu.py`, `test -f tools/crawler/crawl_campus.py`, `test -f data/campus/indexed/campus_knowledge.json`로 확인했고 모두 존재함(성공)으로 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42fa31760832c956847d8bc72eb31)