### PR TITLE
Serve latest matching versioned web assets for stale hashed requests

### DIFF
--- a/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -586,6 +586,37 @@ if WEB_DIR:
 
         return {'Cache-Control': 'public, max-age=300'}
 
+    def _resolve_versioned_asset_alias(requested_path: Path) -> Path | None:
+        """
+        Resolve stale hashed asset names to the newest available file.
+
+        Example:
+          request: assets/index-OLDHASH.js
+          match  : assets/index-NEWHASH.js
+        """
+        if not _is_versioned_asset(requested_path):
+            return None
+
+        parent = WEB_DIR / requested_path.parent
+        if not parent.is_dir():
+            return None
+
+        match = re.match(r'^(?P<base>.+)-(?P<hash>[A-Za-z0-9_-]{6,})$', requested_path.stem)
+        if not match:
+            return None
+
+        expected_prefix = f"{match.group('base')}-"
+        candidates = sorted(
+            p for p in parent.glob(f"{expected_prefix}*{requested_path.suffix}")
+            if p.is_file()
+        )
+        if not candidates:
+            return None
+
+        # Pick the newest candidate so clients converge to the latest deployed chunk.
+        latest = max(candidates, key=lambda p: p.stat().st_mtime)
+        return latest.relative_to(WEB_DIR)
+
 
     @app.get('/{full_path:path}', include_in_schema=False)
     async def serve_spa(full_path: str):
@@ -600,6 +631,14 @@ if WEB_DIR:
             or requested_path.suffix.lower() in _STATIC_FILE_EXTENSIONS
         )
         if is_asset_request:
+            alias_path = _resolve_versioned_asset_alias(requested_path)
+            if alias_path is not None:
+                logger.warning(
+                    'Resolved stale asset request %s -> %s',
+                    requested_path.as_posix(),
+                    alias_path.as_posix(),
+                )
+                return _FileResponse(str(WEB_DIR / alias_path), headers=_static_cache_headers(alias_path))
             raise HTTPException(404, 'Not Found')
 
         # 파일 확장자가 없는 SPA route만 index.html fallback 처리


### PR DESCRIPTION
### Motivation
- The dashboard produced 404s for hashed chunk filenames (e.g. `/assets/index-*.js`, `/assets/panel-hri-*.js`) when clients referenced stale hashed names after a deploy. 
- The intent is to make the static-file server resilient during rollout/cache transition windows so the UI doesn't break while clients still hold old references.

### Description
- Add `_resolve_versioned_asset_alias(requested_path: Path) -> Path | None` to locate newest matching files for requests that look like versioned assets under `web_current/assets` by matching the prefix and picking the most recently modified candidate. 
- Integrate alias resolution into the SPA static handler so that when an asset request would 404 the server first attempts to resolve a stale hashed filename to the latest available chunk and serves it with the proper cache headers. 
- Emit a warning log when a stale asset request is resolved to aid deploy and cache troubleshooting. 
- Modified file: `ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py`.

### Testing
- Ran Python byte-compile check with `python3 -m py_compile ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c06ccbf08326b1bfcb31d0daf313)