### PR TITLE
Add C++ RealSense depth camera node and launch selection

### DIFF
--- a/ros2_ws/src/bringup/launch/perception.launch.py
+++ b/ros2_ws/src/bringup/launch/perception.launch.py
@@ -2,7 +2,7 @@
 Perception stack launch (camera/vision only).
 
 Nodes started:
-  depth_camera_node           (perception_pkg) x 2  - front / rear cameras
+  depth_camera_node           (perception_pkg or perception_camera_cpp) x 2 - front / rear cameras
   person_detection_node       (perception_pkg)
   landmark_detection_node     (perception_pkg)
   gesture_recognition_node    (perception_pkg)
@@ -14,7 +14,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
@@ -39,6 +39,7 @@ def generate_launch_description():
         DeclareLaunchArgument('camera_fps', default_value='15'),
         DeclareLaunchArgument('camera_width', default_value='640'),
         DeclareLaunchArgument('camera_height', default_value='480'),
+        DeclareLaunchArgument('use_cpp_depth_camera', default_value='true'),
     ]
 
     camera_params = {
@@ -49,13 +50,14 @@ def generate_launch_description():
         'align_depth_to_color': True,
     }
 
-    depth_camera_front = Node(
+    depth_camera_front_py = Node(
         package='perception_pkg',
         executable='depth_camera_node',
         name='depth_camera_front',
         namespace='dori/camera/front',
         output='screen',
         parameters=[{**camera_params, 'serial_number': ''}],
+        condition=UnlessCondition(LaunchConfiguration('use_cpp_depth_camera')),
         remappings=[
             ('color/image_raw', '/dori/camera/color/image_raw'),
             ('depth/image_raw', '/dori/camera/depth/image_raw'),
@@ -65,13 +67,14 @@ def generate_launch_description():
         ],
     )
 
-    depth_camera_rear = Node(
+    depth_camera_rear_py = Node(
         package='perception_pkg',
         executable='depth_camera_node',
         name='depth_camera_rear',
         namespace='dori/camera/rear',
         output='screen',
         parameters=[{**camera_params, 'serial_number': ''}],
+        condition=UnlessCondition(LaunchConfiguration('use_cpp_depth_camera')),
         remappings=[
             ('color/image_raw', '/dori/camera/rear/color/image_raw'),
             ('depth/image_raw', '/dori/camera/rear/depth/image_raw'),
@@ -80,6 +83,41 @@ def generate_launch_description():
             ('depth_scale', '/dori/camera/rear/depth_scale'),
         ],
     )
+
+    depth_camera_front_cpp = Node(
+        package='perception_camera_cpp',
+        executable='depth_camera_node',
+        name='depth_camera_front',
+        namespace='dori/camera/front',
+        output='screen',
+        parameters=[{**camera_params, 'serial_number': ''}],
+        condition=IfCondition(LaunchConfiguration('use_cpp_depth_camera')),
+        remappings=[
+            ('color/image_raw', '/dori/camera/color/image_raw'),
+            ('depth/image_raw', '/dori/camera/depth/image_raw'),
+            ('color/camera_info', '/dori/camera/color/camera_info'),
+            ('depth/camera_info', '/dori/camera/depth/camera_info'),
+            ('depth_scale', '/dori/camera/depth_scale'),
+        ],
+    )
+
+    depth_camera_rear_cpp = Node(
+        package='perception_camera_cpp',
+        executable='depth_camera_node',
+        name='depth_camera_rear',
+        namespace='dori/camera/rear',
+        output='screen',
+        parameters=[{**camera_params, 'serial_number': ''}],
+        condition=IfCondition(LaunchConfiguration('use_cpp_depth_camera')),
+        remappings=[
+            ('color/image_raw', '/dori/camera/rear/color/image_raw'),
+            ('depth/image_raw', '/dori/camera/rear/depth/image_raw'),
+            ('color/camera_info', '/dori/camera/rear/color/camera_info'),
+            ('depth/camera_info', '/dori/camera/rear/depth/camera_info'),
+            ('depth_scale', '/dori/camera/rear/depth_scale'),
+        ],
+    )
+
 
     person_detection_node = Node(
         package='perception_pkg',
@@ -137,8 +175,10 @@ def generate_launch_description():
 
     return LaunchDescription([
         *args,
-        depth_camera_front,
-        depth_camera_rear,
+        depth_camera_front_py,
+        depth_camera_rear_py,
+        depth_camera_front_cpp,
+        depth_camera_rear_cpp,
         person_detection_node,
         landmark_detection_node,
         gesture_recognition_node,

--- a/ros2_ws/src/bringup/package.xml
+++ b/ros2_ws/src/bringup/package.xml
@@ -14,6 +14,7 @@
   <exec_depend>llm_pkg</exec_depend>
   <exec_depend>tts_pkg</exec_depend>
   <exec_depend>perception_pkg</exec_depend>
+  <exec_depend>perception_camera_cpp</exec_depend>
   <exec_depend>interaction_pkg</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/ros2_ws/src/perception_camera_cpp/CMakeLists.txt
+++ b/ros2_ws/src/perception_camera_cpp/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.8)
+project(perception_camera_cpp)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(OpenCV REQUIRED)
+find_package(realsense2 REQUIRED)
+
+add_executable(depth_camera_node src/depth_camera_node.cpp)
+ament_target_dependencies(depth_camera_node
+  rclcpp
+  sensor_msgs
+  std_msgs
+  cv_bridge
+)
+target_link_libraries(depth_camera_node
+  ${OpenCV_LIBRARIES}
+  realsense2::realsense2
+)
+
+target_compile_features(depth_camera_node PUBLIC cxx_std_17)
+
+install(TARGETS depth_camera_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/ros2_ws/src/perception_camera_cpp/package.xml
+++ b/ros2_ws/src/perception_camera_cpp/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>perception_camera_cpp</name>
+  <version>0.0.0</version>
+  <description>C++ RealSense camera node for DORI perception stack</description>
+  <maintainer email="jaewon1627@gmail.com">ofbt</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>cv_bridge</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2_ws/src/perception_camera_cpp/src/depth_camera_node.cpp
+++ b/ros2_ws/src/perception_camera_cpp/src/depth_camera_node.cpp
@@ -1,0 +1,216 @@
+#include <chrono>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/imgproc.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <std_msgs/msg/float32.hpp>
+
+#include <librealsense2/rs.hpp>
+
+class DepthCameraNode : public rclcpp::Node {
+public:
+  DepthCameraNode() : Node("depth_camera_node") {
+    width_ = this->declare_parameter<int>("width", 640);
+    height_ = this->declare_parameter<int>("height", 480);
+    fps_ = this->declare_parameter<int>("fps", 30);
+    enable_depth_ = this->declare_parameter<bool>("enable_depth", true);
+    enable_color_ = this->declare_parameter<bool>("enable_color", true);
+    align_depth_to_color_ = this->declare_parameter<bool>("align_depth_to_color", true);
+    depth_scale_publish_ = this->declare_parameter<bool>("depth_scale_publish", true);
+    serial_number_ = this->declare_parameter<std::string>("serial_number", "");
+
+    color_pub_ = this->create_publisher<sensor_msgs::msg::Image>("color/image_raw", 10);
+    depth_pub_ = this->create_publisher<sensor_msgs::msg::Image>("depth/image_raw", 10);
+    color_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>("color/camera_info", 10);
+    depth_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>("depth/camera_info", 10);
+    depth_scale_pub_ = this->create_publisher<std_msgs::msg::Float32>("depth_scale", 10);
+
+    try {
+      rs2::config config;
+      if (!serial_number_.empty()) {
+        config.enable_device(serial_number_);
+      }
+      if (enable_color_) {
+        config.enable_stream(rs2_stream::RS2_STREAM_COLOR, width_, height_, rs2_format::RS2_FORMAT_BGR8, fps_);
+      }
+      if (enable_depth_) {
+        config.enable_stream(rs2_stream::RS2_STREAM_DEPTH, width_, height_, rs2_format::RS2_FORMAT_Z16, fps_);
+      }
+
+      profile_ = pipeline_.start(config);
+
+      if (align_depth_to_color_) {
+        align_ = std::make_unique<rs2::align>(rs2_stream::RS2_STREAM_COLOR);
+      }
+
+      auto depth_sensor = profile_.get_device().first_depth_sensor();
+      depth_scale_ = depth_sensor.get_depth_scale();
+      RCLCPP_INFO(this->get_logger(), "Depth scale: %.6f m/unit", depth_scale_);
+
+      auto period = std::chrono::duration<double>(1.0 / static_cast<double>(fps_));
+      timer_ = this->create_wall_timer(
+        std::chrono::duration_cast<std::chrono::milliseconds>(period),
+        std::bind(&DepthCameraNode::timer_callback, this));
+
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Depth Camera Node started: %dx%d @ %dfps, align=%s",
+        width_, height_, fps_, align_depth_to_color_ ? "true" : "false");
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to start RealSense pipeline: %s", e.what());
+      throw;
+    }
+  }
+
+  ~DepthCameraNode() override {
+    try {
+      pipeline_.stop();
+      RCLCPP_INFO(this->get_logger(), "RealSense pipeline stopped");
+    } catch (...) {
+    }
+  }
+
+private:
+  sensor_msgs::msg::CameraInfo build_camera_info(const rs2_intrinsics & intrinsics, const builtin_interfaces::msg::Time & stamp, const std::string & frame_id) const {
+    sensor_msgs::msg::CameraInfo info;
+    info.header.stamp = stamp;
+    info.header.frame_id = frame_id;
+    info.width = static_cast<uint32_t>(intrinsics.width);
+    info.height = static_cast<uint32_t>(intrinsics.height);
+    info.distortion_model = "plumb_bob";
+
+    info.d.resize(5);
+    for (size_t i = 0; i < 5; ++i) {
+      info.d[i] = intrinsics.coeffs[i];
+    }
+
+    const double fx = intrinsics.fx;
+    const double fy = intrinsics.fy;
+    const double cx = intrinsics.ppx;
+    const double cy = intrinsics.ppy;
+
+    info.k = {fx, 0.0, cx,
+              0.0, fy, cy,
+              0.0, 0.0, 1.0};
+
+    info.r = {1.0, 0.0, 0.0,
+              0.0, 1.0, 0.0,
+              0.0, 0.0, 1.0};
+
+    info.p = {fx, 0.0, cx, 0.0,
+              0.0, fy, cy, 0.0,
+              0.0, 0.0, 1.0, 0.0};
+
+    return info;
+  }
+
+  void timer_callback() {
+    rs2::frameset frames;
+    try {
+      frames = pipeline_.wait_for_frames(100);
+    } catch (const std::exception &) {
+      RCLCPP_WARN(this->get_logger(), "RealSense frame acquisition timeout");
+      return;
+    }
+
+    if (align_) {
+      frames = align_->process(frames);
+    }
+
+    const auto now = this->get_clock()->now().to_msg();
+
+    if (depth_scale_publish_) {
+      std_msgs::msg::Float32 msg;
+      msg.data = depth_scale_;
+      depth_scale_pub_->publish(msg);
+    }
+
+    if (enable_color_) {
+      const auto color_frame = frames.get_color_frame();
+      if (color_frame) {
+        const auto w = color_frame.get_width();
+        const auto h = color_frame.get_height();
+        const auto * color_data = reinterpret_cast<const uint8_t *>(color_frame.get_data());
+        cv::Mat color_mat(h, w, CV_8UC3, const_cast<uint8_t *>(color_data), cv::Mat::AUTO_STEP);
+
+        auto color_msg = cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", color_mat).toImageMsg();
+        color_msg->header.stamp = now;
+        color_msg->header.frame_id = "camera_color_optical_frame";
+        color_pub_->publish(*color_msg);
+
+        if (!color_intrinsics_cached_) {
+          auto vsp = color_frame.get_profile().as<rs2::video_stream_profile>();
+          color_intrinsics_ = vsp.get_intrinsics();
+          color_intrinsics_cached_ = true;
+        }
+        color_info_pub_->publish(build_camera_info(color_intrinsics_, now, "camera_color_optical_frame"));
+      }
+    }
+
+    if (enable_depth_) {
+      const auto depth_frame = frames.get_depth_frame();
+      if (depth_frame) {
+        const auto w = depth_frame.get_width();
+        const auto h = depth_frame.get_height();
+        const auto * depth_data = reinterpret_cast<const uint16_t *>(depth_frame.get_data());
+
+        cv::Mat depth_mat(h, w, CV_16UC1, const_cast<uint16_t *>(depth_data), cv::Mat::AUTO_STEP);
+        auto depth_msg = cv_bridge::CvImage(std_msgs::msg::Header(), "16UC1", depth_mat).toImageMsg();
+        depth_msg->header.stamp = now;
+        depth_msg->header.frame_id = "camera_depth_optical_frame";
+        depth_pub_->publish(*depth_msg);
+
+        if (!depth_intrinsics_cached_) {
+          auto vsp = depth_frame.get_profile().as<rs2::video_stream_profile>();
+          depth_intrinsics_ = vsp.get_intrinsics();
+          depth_intrinsics_cached_ = true;
+        }
+        depth_info_pub_->publish(build_camera_info(depth_intrinsics_, now, "camera_depth_optical_frame"));
+      }
+    }
+  }
+
+  int width_;
+  int height_;
+  int fps_;
+  bool enable_depth_;
+  bool enable_color_;
+  bool align_depth_to_color_;
+  bool depth_scale_publish_;
+  std::string serial_number_;
+
+  rs2::pipeline pipeline_;
+  rs2::pipeline_profile profile_;
+  std::unique_ptr<rs2::align> align_;
+
+  float depth_scale_ {0.001f};
+  bool color_intrinsics_cached_ {false};
+  bool depth_intrinsics_cached_ {false};
+  rs2_intrinsics color_intrinsics_ {};
+  rs2_intrinsics depth_intrinsics_ {};
+
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr color_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr color_info_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr depth_info_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr depth_scale_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char ** argv) {
+  rclcpp::init(argc, argv);
+  try {
+    auto node = std::make_shared<DepthCameraNode>();
+    rclcpp::spin(node);
+  } catch (const std::exception & e) {
+    fprintf(stderr, "Fatal error in depth_camera_node: %s\n", e.what());
+  }
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a native C++ RealSense camera node for higher-performance/stability RealSense frame capture, depth-to-color alignment, and depth-scale publishing. 
- Preserve the existing runtime contract so downstream nodes continue to consume the same topics and frame IDs. 
- Make the system able to switch between the existing Python node and the new C++ node from the top-level perception launch. 

### Description
- Added a new `perception_camera_cpp` ROS2 package (`ament_cmake`) containing `CMakeLists.txt`, `package.xml`, and `src/depth_camera_node.cpp` which implements RealSense pipeline setup, optional depth->color alignment, and timed frame publishing. 
- The C++ node publishes `Image` and `CameraInfo` on the existing relative topic names (`color/image_raw`, `depth/image_raw`, `color/camera_info`, `depth/camera_info`) and publishes depth scale as `std_msgs/Float32` on `depth_scale`, while keeping frame IDs `camera_color_optical_frame` and `camera_depth_optical_frame`. 
- Updated `bringup/launch/perception.launch.py` to add the launch argument `use_cpp_depth_camera` (default `true`) and to conditionally launch either the original Python `depth_camera_node` (when false) or the new C++ `depth_camera_node` from `perception_camera_cpp` (when true) using `IfCondition`/`UnlessCondition` and remappings to maintain absolute `/dori/camera/...` topic names. 
- Added `perception_camera_cpp` as an `<exec_depend>` in `bringup/package.xml` so the bringup launch references are declared. 

### Testing
- Ran `python3 -m py_compile ros2_ws/src/bringup/launch/perception.launch.py` which returned `OK`. 
- Attempted to run `colcon build --packages-select perception_camera_cpp bringup` but the environment does not have `colcon` installed so a full package build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4cc46b3d88326a96da9ac09f1ce25)