### PR TITLE
Run `colcon build` from ros2_ws and add guard for missing workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Get your Porcupine key for free at [Picovoice Console](https://console.picovoice
 
 ```bash
 source /opt/ros/humble/setup.bash
+cd ros2_ws
 colcon build --symlink-install
 source install/setup.bash
 ```
@@ -146,6 +147,7 @@ The dashboard frontend must be built before the first run.
 ```bash
 # First time only — build the frontend assets
 cd web && npm ci && npm run build && cd ..
+cd ros2_ws
 colcon build --symlink-install
 source install/setup.bash
  

--- a/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -73,6 +73,7 @@ parser_arg.add_argument('--web-dir', default='')
 args, _ = parser_arg.parse_known_args()
 
 REPO_ROOT   = Path(args.repo_root)
+ROS2_WS_ROOT = REPO_ROOT / 'ros2_ws'
 PARSER_SCRIPT  = REPO_ROOT / 'tools' / 'parser' / 'parse_cafeteria_menu.py'
 BUILDER_SCRIPT = REPO_ROOT / 'ros2_ws' / 'src' / 'llm_pkg' / 'llm_pkg' / 'build_index.py'
 CRAWLER_SCRIPT = REPO_ROOT / 'tools' / 'crawler' / 'crawl_campus.py'
@@ -1068,13 +1069,21 @@ def _deploy_pipeline(*, force_web_repair: bool = False):
             'log': 'Packages selected: ' + ', '.join(packages_to_build),
         })
         package_args = ' '.join(shlex.quote(pkg) for pkg in packages_to_build)
+        if not ROS2_WS_ROOT.is_dir():
+            _deploy_job.update({
+                'status': 'error',
+                'error': f'ROS2 workspace not found: {ROS2_WS_ROOT}',
+                'finished_at': datetime.datetime.now().isoformat(),
+            })
+            return
+
         ok, _ = _run_step(
             'colcon build',
             [
                 'bash', '-c',
                 f'source {ros_setup} && colcon build --symlink-install --packages-select {package_args}'
             ],
-            cwd=repo,
+            cwd=str(ROS2_WS_ROOT),
         )
         if not ok:
             _deploy_job.update({'status': 'error', 'error': 'colcon build failed',


### PR DESCRIPTION
### Motivation
- Builds failed after packages were moved under `ros2_ws/src` because `colcon` was being invoked from the repository root and CMake looked for `.../src/<pkg>` in the wrong place. 
- The deploy pipeline and README needed to reflect the relocated workspace so build commands use the correct working directory.

### Description
- Added `ROS2_WS_ROOT = REPO_ROOT / 'ros2_ws'` and changed the `colcon build` invocation to run with `cwd=str(ROS2_WS_ROOT)` in `ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py` so builds run from the ROS2 workspace. 
- Added a guard that returns a clear error when `ros2_ws` is missing before attempting the build. 
- Updated `README.md` build instructions to `cd ros2_ws` before running `colcon build` to match the current workspace layout.

### Testing
- Ran `python3 -m py_compile ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4dd090db8832694ad07d799bf8906)