### PR TITLE
Fix campus crawler path resolution in dashboard launch/API

### DIFF
--- a/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -64,6 +64,17 @@ def find_repo_root(start: Path) -> Path:
     return start  # fallback
 
 
+def normalize_repo_root(candidate: Path) -> Path:
+    """Normalize an explicit --repo-root path to the actual repository root."""
+    resolved = candidate.expanduser().resolve()
+    for parent in [resolved, *resolved.parents]:
+        has_ros2_src = (parent / 'ros2_ws' / 'src').is_dir()
+        has_crawler = (parent / 'tools' / 'crawler' / 'crawl_campus.py').is_file()
+        if has_ros2_src and has_crawler:
+            return parent
+    return resolved
+
+
 DEFAULT_REPO = find_repo_root(Path(__file__).resolve().parent)
 
 parser_arg = argparse.ArgumentParser(add_help=False)
@@ -72,7 +83,7 @@ parser_arg.add_argument('--port', type=int, default=3000)
 parser_arg.add_argument('--web-dir', default='')
 args, _ = parser_arg.parse_known_args()
 
-REPO_ROOT   = Path(args.repo_root)
+REPO_ROOT   = normalize_repo_root(Path(args.repo_root))
 ROS2_WS_ROOT = REPO_ROOT / 'ros2_ws'
 PARSER_SCRIPT  = REPO_ROOT / 'tools' / 'parser' / 'parse_cafeteria_menu.py'
 BUILDER_SCRIPT = REPO_ROOT / 'ros2_ws' / 'src' / 'llm_pkg' / 'llm_pkg' / 'build_index.py'

--- a/ros2_ws/src/dashboard_pkg/launch/dashboard.launch.py
+++ b/ros2_ws/src/dashboard_pkg/launch/dashboard.launch.py
@@ -9,6 +9,7 @@ To enable: ros2 launch dashboard_pkg dashboard.launch.py tunnel:=true
 
 import os
 import shutil
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -16,6 +17,19 @@ from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+
+
+def _resolve_repo_root(pkg_dir: str) -> str:
+    """Resolve repository root from an installed dashboard package path."""
+    start = Path(pkg_dir).resolve()
+    for candidate in [start, *start.parents]:
+        has_ros2_src = (candidate / 'ros2_ws' / 'src').is_dir()
+        has_crawler = (candidate / 'tools' / 'crawler' / 'crawl_campus.py').is_file()
+        if has_ros2_src and has_crawler:
+            return str(candidate)
+
+    # Fallback: keep legacy relative behavior.
+    return os.path.abspath(os.path.join(pkg_dir, '..', '..', '..', '..'))
 
 
 def _make_tunnel_actions(context, *args, **kwargs):
@@ -91,7 +105,7 @@ def _make_api_server_action(context, *args, **kwargs):
     web_dir   = os.path.join(pkg_dir, 'web_current')
     if not os.path.isdir(web_dir):
         web_dir = os.path.join(pkg_dir, 'web')
-    repo_root = os.path.abspath(os.path.join(pkg_dir, '..', '..', '..', '..'))
+    repo_root = _resolve_repo_root(pkg_dir)
     knowledge_api_script = os.path.join(pkg_dir, 'scripts', 'knowledge_api.py')
 
     dashboard_url = LaunchConfiguration('dashboard_url').perform(context)
@@ -130,7 +144,7 @@ def generate_launch_description():
             'completed static tree before launching the dashboard.'
         )
 
-    repo_root = os.path.abspath(os.path.join(pkg_dir, '..', '..', '..', '..'))
+    repo_root = _resolve_repo_root(pkg_dir)
     knowledge_api_script = os.path.join(pkg_dir, 'scripts', 'knowledge_api.py')
 
     return LaunchDescription([


### PR DESCRIPTION
### Motivation
- The dashboard was passing an incorrect repository root to the knowledge API when `dashboard_pkg` is installed, causing the crawler lookup to point at `.../ros2_ws/tools/crawler/crawl_campus.py` instead of the real repo `tools/crawler/crawl_campus.py`.
- The change aims to reliably detect the actual project root so tools like the Campus Crawler are resolved at their correct location.

### Description
- Added `_resolve_repo_root(pkg_dir: str)` to `ros2_ws/src/dashboard_pkg/launch/dashboard.launch.py` to walk parent directories and detect the real repository root (checks for `ros2_ws/src` and `tools/crawler/crawl_campus.py`) and use it instead of the fixed four-level relative lookup.
- Added `normalize_repo_root(candidate: Path) -> Path` to `ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py` to normalize an explicit `--repo-root` argument by scanning parents for repo markers and the crawler script.
- Replaced `REPO_ROOT = Path(args.repo_root)` with `REPO_ROOT = normalize_repo_root(Path(args.repo_root))` and made the launch file pass the resolved `repo_root` to the API invocation so `CRAWLER_SCRIPT` is computed from the corrected root.
- Kept a fallback to the legacy relative behavior when the repository markers are not found.

### Testing
- Ran `python3 -m py_compile ros2_ws/src/dashboard_pkg/launch/dashboard.launch.py ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f01c256c832681b64519a2ac6781)