### PR TITLE
Unify depth camera topic naming policy (relative topics + launch remapping)

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -76,6 +76,15 @@ ros2_ws/src/
 
 ### ROS2 Topic Map (Actual Nodes)
 
+#### Camera topic naming policy (Python/C++ depth camera parity)
+
+- Canonical rule: depth camera nodes must publish to **relative topics** (e.g. `color/image_raw`, `depth/image_raw`) inside node code.
+- Launch files own final routing by injecting `/dori` namespace/remapping to app-level canonical topics (e.g. `/dori/camera/color/image_raw`).
+- Do not hardcode absolute `/dori/...` camera publish topics inside node implementations.
+- This rule applies equally to:
+  - `perception_pkg/perception_pkg/depth_camera_node.py` (Python)
+  - `perception_camera_cpp/src/depth_camera_node.cpp` (C++)
+
 This map is reconstructed from the current node implementations:
 - `perception_pkg/*_node.py`
 - `interaction_pkg/hri_manager_node.py`

--- a/ros2_ws/src/bringup/launch/perception.launch.py
+++ b/ros2_ws/src/bringup/launch/perception.launch.py
@@ -67,6 +67,7 @@ def generate_launch_description():
         remappings=[
             ('color/image_raw', _topic(dori_ns, '/camera/color/image_raw')),
             ('depth/image_raw', _topic(dori_ns, '/camera/depth/image_raw')),
+            ('depth/image_colormap', _topic(dori_ns, '/camera/depth/image_colormap')),
             ('color/camera_info', _topic(dori_ns, '/camera/color/camera_info')),
             ('depth/camera_info', _topic(dori_ns, '/camera/depth/camera_info')),
             ('depth_scale', _topic(dori_ns, '/camera/depth_scale')),
@@ -84,6 +85,7 @@ def generate_launch_description():
         remappings=[
             ('color/image_raw', _topic(dori_ns, '/camera/rear/color/image_raw')),
             ('depth/image_raw', _topic(dori_ns, '/camera/rear/depth/image_raw')),
+            ('depth/image_colormap', _topic(dori_ns, '/camera/rear/depth/image_colormap')),
             ('color/camera_info', _topic(dori_ns, '/camera/rear/color/camera_info')),
             ('depth/camera_info', _topic(dori_ns, '/camera/rear/depth/camera_info')),
             ('depth_scale', _topic(dori_ns, '/camera/rear/depth_scale')),

--- a/ros2_ws/src/perception_camera_cpp/README.md
+++ b/ros2_ws/src/perception_camera_cpp/README.md
@@ -1,0 +1,10 @@
+# perception_camera_cpp
+
+## Depth camera topic policy
+
+`src/depth_camera_node.cpp` follows the same rule as Python implementation:
+
+- Node code publishes to **relative topics** (`color/image_raw`, `depth/image_raw`, `color/camera_info`, `depth/camera_info`, `depth_scale`) using parameters.
+- Launch (`bringup/launch/perception.launch.py`) injects namespace/remappings to canonical app topics under `/dori/...`.
+
+This keeps Python/C++ depth camera implementations topic-compatible and prevents hardcoded absolute topic drift.

--- a/ros2_ws/src/perception_camera_cpp/src/depth_camera_node.cpp
+++ b/ros2_ws/src/perception_camera_cpp/src/depth_camera_node.cpp
@@ -24,12 +24,17 @@ public:
     align_depth_to_color_ = this->declare_parameter<bool>("align_depth_to_color", true);
     depth_scale_publish_ = this->declare_parameter<bool>("depth_scale_publish", true);
     serial_number_ = this->declare_parameter<std::string>("serial_number", "");
+    color_topic_ = this->declare_parameter<std::string>("topics.color_pub", "color/image_raw");
+    depth_topic_ = this->declare_parameter<std::string>("topics.depth_pub", "depth/image_raw");
+    color_info_topic_ = this->declare_parameter<std::string>("topics.color_info_pub", "color/camera_info");
+    depth_info_topic_ = this->declare_parameter<std::string>("topics.depth_info_pub", "depth/camera_info");
+    depth_scale_topic_ = this->declare_parameter<std::string>("topics.depth_scale_pub", "depth_scale");
 
-    color_pub_ = this->create_publisher<sensor_msgs::msg::Image>("color/image_raw", 10);
-    depth_pub_ = this->create_publisher<sensor_msgs::msg::Image>("depth/image_raw", 10);
-    color_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>("color/camera_info", 10);
-    depth_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>("depth/camera_info", 10);
-    depth_scale_pub_ = this->create_publisher<std_msgs::msg::Float32>("depth_scale", 10);
+    color_pub_ = this->create_publisher<sensor_msgs::msg::Image>(color_topic_, 10);
+    depth_pub_ = this->create_publisher<sensor_msgs::msg::Image>(depth_topic_, 10);
+    color_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>(color_info_topic_, 10);
+    depth_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>(depth_info_topic_, 10);
+    depth_scale_pub_ = this->create_publisher<std_msgs::msg::Float32>(depth_scale_topic_, 10);
 
     try {
       rs2::config config;
@@ -201,6 +206,11 @@ private:
   bool align_depth_to_color_;
   bool depth_scale_publish_;
   std::string serial_number_;
+  std::string color_topic_;
+  std::string depth_topic_;
+  std::string color_info_topic_;
+  std::string depth_info_topic_;
+  std::string depth_scale_topic_;
 
   rs2::pipeline pipeline_;
   rs2::pipeline_profile profile_;

--- a/ros2_ws/src/perception_pkg/README.md
+++ b/ros2_ws/src/perception_pkg/README.md
@@ -1,0 +1,21 @@
+# perception_pkg
+
+## Depth camera topic policy
+
+`perception_pkg/perception_pkg/depth_camera_node.py` uses **relative publish topic defaults**:
+
+- `color/image_raw`
+- `depth/image_raw`
+- `depth/image_colormap`
+- `color/camera_info`
+- `depth/camera_info`
+
+Production topic names are finalized in launch (`bringup/launch/perception.launch.py`) via namespace/remapping, for example:
+
+- `/dori/camera/color/image_raw`
+- `/dori/camera/depth/image_raw`
+- `/dori/camera/depth/image_colormap`
+- `/dori/camera/color/camera_info`
+- `/dori/camera/depth/camera_info`
+
+Do not hardcode absolute `/dori/...` camera publish topics inside node code.

--- a/ros2_ws/src/perception_pkg/perception_pkg/depth_camera_node.py
+++ b/ros2_ws/src/perception_pkg/perception_pkg/depth_camera_node.py
@@ -25,12 +25,12 @@ class DepthCameraNode(Node):
         self.declare_parameter('enable_depth', True)
         self.declare_parameter('enable_color', True)
         self.declare_parameter('align_depth_to_color', True)
-        self.declare_parameter('depth_scale_publish', True)  # /dori/camera/depth_scale
-        self.declare_parameter('topics.color_pub', '/dori/camera/color/image_raw')
-        self.declare_parameter('topics.depth_pub', '/dori/camera/depth/image_raw')
-        self.declare_parameter('topics.depth_colormap_pub', '/dori/camera/depth/image_colormap')
-        self.declare_parameter('topics.color_info_pub', '/dori/camera/color/camera_info')
-        self.declare_parameter('topics.depth_info_pub', '/dori/camera/depth/camera_info')
+        self.declare_parameter('depth_scale_publish', True)
+        self.declare_parameter('topics.color_pub', 'color/image_raw')
+        self.declare_parameter('topics.depth_pub', 'depth/image_raw')
+        self.declare_parameter('topics.depth_colormap_pub', 'depth/image_colormap')
+        self.declare_parameter('topics.color_info_pub', 'color/camera_info')
+        self.declare_parameter('topics.depth_info_pub', 'depth/camera_info')
 
         self.width = self.get_parameter('width').value
         self.height = self.get_parameter('height').value


### PR DESCRIPTION
### Motivation

- Node implementations were inconsistent about camera publish topics which caused coupling to the `/dori` app namespace.
- Standardize on the rule that node code publishes to relative topics and launch files inject the final `/dori/...` namespace/remappings.

### Description

- Change Python depth camera defaults in `perception_pkg/perception_pkg/depth_camera_node.py` from absolute `/dori/...` names to relative defaults such as `color/image_raw`, `depth/image_raw`, `depth/image_colormap`, `color/camera_info`, and `depth/camera_info`.
- Add `topics.*` parameters to `perception_camera_cpp/src/depth_camera_node.cpp` with relative defaults and use those parameter values when creating publishers instead of hardcoded names.
- Update `bringup/launch/perception.launch.py` to remap the Python node's `depth/image_colormap` so launch performs the final routing into the `/dori` namespace for both front and rear cameras.
- Document the chosen policy in `docs/dev/architecture.md` and add package README files (`ros2_ws/src/perception_pkg/README.md` and `ros2_ws/src/perception_camera_cpp/README.md`) describing the topic naming policy.

### Testing

- Ran `python3 -m py_compile ros2_ws/src/perception_pkg/perception_pkg/depth_camera_node.py` and it succeeded.
- Ran a repository search (`rg -n "topics\.color_pub|topics\.depth_pub|topics\.color_info_pub|topics\.depth_info_pub|topics\.depth_scale_pub|image_colormap"`) to verify parameter names and remappings and checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f784662883268c96e2214c0aee59)