### PR TITLE
Prevent infinite loop in chunk_text and validate window parameters

### DIFF
--- a/ros2_ws/src/llm_pkg/llm_pkg/build_index.py
+++ b/ros2_ws/src/llm_pkg/llm_pkg/build_index.py
@@ -49,6 +49,11 @@ def chunk_text(text: str, size: int = CHUNK_SIZE, overlap: int = CHUNK_OVERLAP) 
     Split text into overlapping character-level chunks.
     Tries to break at newlines first to avoid mid-sentence splits.
     """
+    if size <= 0:
+        raise ValueError("size must be > 0")
+    if overlap >= size:
+        overlap = size - 1
+
     chunks = []
     start = 0
     while start < len(text):
@@ -63,7 +68,12 @@ def chunk_text(text: str, size: int = CHUNK_SIZE, overlap: int = CHUNK_OVERLAP) 
         chunk = text[start:end].strip()
         if chunk:
             chunks.append(chunk)
-        start = end - overlap
+
+        if end >= len(text):
+            break
+
+        next_start = max(start + 1, end - overlap)
+        start = next_start
 
     return chunks
 


### PR DESCRIPTION
### Motivation
- Prevent potential infinite loops in `chunk_text` when `overlap` is large or the start index does not advance, and make the function fail fast on invalid parameters.

### Description
- Add a guard to raise `ValueError` when `size <= 0` and clamp `overlap` to `size - 1` when `overlap >= size` to prevent unsafe window widths.
- After appending the final chunk, break immediately when `end >= len(text)` to guarantee loop termination for the last window.
- Compute the next start as `next_start = max(start + 1, end - overlap)` and assign it to `start` to ensure `start` always progresses monotically and cannot repeat.
- No public API changes beyond safer parameter handling and guaranteed progress/termination in chunking.

### Testing
- Ran minimal reproduction checks by calling `chunk_text` with short text, exact-boundary text, and newline-containing text, and verified the function returned finite chunk lists as expected (succeeded).
- Tested `overlap >= size` behavior by invoking `chunk_text` with `overlap` equal to `size` and confirmed chunking proceeded without infinite looping (succeeded).
- Verified that `size = 0` raises `ValueError` (succeeded).
- Note: an initial attempt to import the module failed due to `numpy` not being installed in the environment, so tests were executed after providing a lightweight shim to permit import; the functional checks above all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52f9392548326bd0dc864bbee8c86)