### PR TITLE
Add cursor-based incremental log polling for index builds

### DIFF
--- a/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -33,7 +33,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, File, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -241,16 +241,18 @@ async def build_index(body: dict):
 
 
 @app.get('/api/knowledge/build-index/status/{job_id}')
-async def build_index_status(job_id: str):
+async def build_index_status(job_id: str, cursor: int = Query(0, ge=0)):
     job = _jobs.get(job_id)
     if not job:
         raise HTTPException(404, 'Job not found')
 
-    # Return new lines since last poll (client tracks cursor)
-    # Simple approach: always return full lines (small output)
+    lines = job['lines']
+    safe_cursor = min(cursor, len(lines))
+
     return {
         'status': job['status'],
-        'new_lines': job['lines'],
+        'new_lines': lines[safe_cursor:],
+        'next_cursor': len(lines),
         'total_chunks': job['total_chunks'],
         'error': job['error'],
     }

--- a/web/src/panels/perception/IndexBuilderPanel.jsx
+++ b/web/src/panels/perception/IndexBuilderPanel.jsx
@@ -34,9 +34,22 @@ function IndexBuilderPanel() {
   const [incremental, setIncremental] = useState(true);
   const [indexInfo, setIndexInfo] = useState(null);
   const pollRef = useRef(null);
+  const cursorRef = useRef(0);
+  const seenLineHashesRef = useRef(new Set());
 
   function appendLog(msg) {
     setLog((prev) => [...prev, `${new Date().toLocaleTimeString()}  ${msg}`]);
+  }
+
+  function appendUniqueLines(lines) {
+    const uniqueLines = [];
+    for (const line of lines ?? []) {
+      const key = JSON.stringify(line);
+      if (seenLineHashesRef.current.has(key)) continue;
+      seenLineHashesRef.current.add(key);
+      uniqueLines.push(line);
+    }
+    uniqueLines.forEach((line) => appendLog(line));
   }
 
   const fetchIndexInfo = useCallback(async () => {
@@ -53,6 +66,9 @@ function IndexBuilderPanel() {
   async function handleBuild() {
     setStatus('running');
     setLog([]);
+    cursorRef.current = 0;
+    seenLineHashesRef.current = new Set();
+    clearInterval(pollRef.current);
     appendLog(`Starting ${incremental ? 'incremental' : 'full'} index rebuild…`);
 
     try {
@@ -68,9 +84,15 @@ function IndexBuilderPanel() {
       appendLog(`Job started: ${jobId}`);
 
       pollRef.current = setInterval(async () => {
-        const r = await fetch(`${API}/build-index/status/${jobId}`);
+        const currentCursor = cursorRef.current;
+        const r = await fetch(`${API}/build-index/status/${jobId}?cursor=${currentCursor}`);
         const d = await r.json();
-        d.new_lines?.forEach((l) => appendLog(l));
+        appendUniqueLines(d.new_lines);
+        if (typeof d.next_cursor === 'number') {
+          cursorRef.current = Math.max(currentCursor, d.next_cursor);
+        } else {
+          cursorRef.current = currentCursor + (d.new_lines?.length ?? 0);
+        }
         if (d.status === 'done') {
           clearInterval(pollRef.current);
           appendLog(`[OK] Done — ${d.total_chunks} chunks indexed.`);


### PR DESCRIPTION
### Motivation
- Reduce redundant log traffic and client-side duplicate appends by making the build status endpoint support stateless cursor-based pagination.
- Ensure the frontend receives only newly produced lines per poll and can deduplicate any repeated lines while preserving existing interval cleanup behavior.

### Description
- Added a `cursor` query parameter to `GET /api/knowledge/build-index/status/{job_id}` and imported `Query` from FastAPI to validate it.
- The status endpoint now returns `new_lines` as `lines[cursor:]` and includes `next_cursor` (the current length of `lines`) while bounding the provided cursor with `min(cursor, len(lines))`; changes in `ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py`.
- Updated `IndexBuilderPanel.jsx` to track the poll cursor with `cursorRef` and send `?cursor=...` on each poll, and to update the cursor from `next_cursor` or fallback to length-based advancement; changes in `web/src/panels/perception/IndexBuilderPanel.jsx`.
- Added `seenLineHashesRef` and `appendUniqueLines` to the panel to prevent duplicate appends (uses JSON stringification as a simple line hash) and reset cursor/hash/interval when starting a new build while keeping interval clear logic on done/error and unmount.

### Testing
- Ran Python syntax check with `python3 -m py_compile ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py` which succeeded.
- Ran frontend lint with `npm --prefix web run -s lint` which failed due to pre-existing lint errors in unrelated files, not caused by these changes (no build-time JS errors observed for the modified module itself).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5629e1480832c9070a7d6d49ac040)