### PR TITLE
Restrict IndexBuilderPanel log dedupe to per-poll batches and preserve timeline

### DIFF
--- a/web/src/panels/perception/IndexBuilderPanel.jsx
+++ b/web/src/panels/perception/IndexBuilderPanel.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import './IndexBuilderPanel.css';
+import { normalizePollLines } from './logUtils';
 
 const API = '/api/knowledge';
 
@@ -35,21 +36,14 @@ function IndexBuilderPanel() {
   const [indexInfo, setIndexInfo] = useState(null);
   const pollRef = useRef(null);
   const cursorRef = useRef(0);
-  const seenLineHashesRef = useRef(new Set());
 
   function appendLog(msg) {
     setLog((prev) => [...prev, `${new Date().toLocaleTimeString()}  ${msg}`]);
   }
 
-  function appendUniqueLines(lines) {
-    const uniqueLines = [];
-    for (const line of lines ?? []) {
-      const key = JSON.stringify(line);
-      if (seenLineHashesRef.current.has(key)) continue;
-      seenLineHashesRef.current.add(key);
-      uniqueLines.push(line);
-    }
-    uniqueLines.forEach((line) => appendLog(line));
+  function appendPolledLines(lines) {
+    const normalizedLines = normalizePollLines(lines, { dedupeWithinBatch: true });
+    normalizedLines.forEach((line) => appendLog(line));
   }
 
   const fetchIndexInfo = useCallback(async () => {
@@ -67,7 +61,6 @@ function IndexBuilderPanel() {
     setStatus('running');
     setLog([]);
     cursorRef.current = 0;
-    seenLineHashesRef.current = new Set();
     clearInterval(pollRef.current);
     appendLog(`Starting ${incremental ? 'incremental' : 'full'} index rebuild…`);
 
@@ -87,7 +80,7 @@ function IndexBuilderPanel() {
         const currentCursor = cursorRef.current;
         const r = await fetch(`${API}/build-index/status/${jobId}?cursor=${currentCursor}`);
         const d = await r.json();
-        appendUniqueLines(d.new_lines);
+        appendPolledLines(d.new_lines);
         if (typeof d.next_cursor === 'number') {
           cursorRef.current = Math.max(currentCursor, d.next_cursor);
         } else {

--- a/web/src/panels/perception/logUtils.js
+++ b/web/src/panels/perception/logUtils.js
@@ -1,0 +1,16 @@
+export function normalizePollLines(lines, { dedupeWithinBatch = true } = {}) {
+  if (!Array.isArray(lines) || lines.length === 0) return [];
+  if (!dedupeWithinBatch) return [...lines];
+
+  const seenInBatch = new Set();
+  const normalized = [];
+
+  for (const line of lines) {
+    const key = JSON.stringify(line);
+    if (seenInBatch.has(key)) continue;
+    seenInBatch.add(key);
+    normalized.push(line);
+  }
+
+  return normalized;
+}

--- a/web/src/panels/perception/logUtils.test.js
+++ b/web/src/panels/perception/logUtils.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizePollLines } from './logUtils.js';
+
+test('keeps identical lines across separate poll responses to preserve timeline', () => {
+  const firstPoll = normalizePollLines(['[INFO] chunk-1 processed']);
+  const secondPoll = normalizePollLines(['[INFO] chunk-1 processed']);
+
+  const timeline = [...firstPoll, ...secondPoll];
+
+  assert.deepEqual(timeline, ['[INFO] chunk-1 processed', '[INFO] chunk-1 processed']);
+});
+
+test('dedupes duplicates only within the same poll response', () => {
+  const samePoll = normalizePollLines(['A', 'A', 'B', 'A']);
+
+  assert.deepEqual(samePoll, ['A', 'B']);
+});


### PR DESCRIPTION
### Motivation
- The previous global `Set`-based dedupe suppressed identical log lines across separate poll responses and could hide timeline ordering even though the server provides cursor-based incremental delivery. 
- Keep server-delivered ordering intact by appending received lines in arrival order while still avoiding noisy duplicates that occur inside a single poll response.

### Description
- Removed the cross-poll `seenLineHashesRef` and its global dedupe logic from `IndexBuilderPanel.jsx` and switched to appending poll results in receive order using a new `appendPolledLines` helper that delegates to a normalizer.  
- Added `web/src/panels/perception/logUtils.js` with `normalizePollLines(lines, { dedupeWithinBatch })` which by default only deduplicates duplicates within the same poll response.  
- `IndexBuilderPanel.jsx` now imports `normalizePollLines` and calls `appendPolledLines(d.new_lines)` inside the poll loop.  
- Added unit tests in `web/src/panels/perception/logUtils.test.js` that verify identical lines across separate poll calls are preserved in the timeline and that duplicates are removed only within a single poll response.

### Testing
- Ran the new unit tests with `cd web && node --test src/panels/perception/logUtils.test.js`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56e92041c832cb19dcfdc00da216d)