### PR TITLE
Add configurable batch_size and chunk_batch_size to index builder (backend + UI)

### DIFF
--- a/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -205,7 +205,12 @@ async def parse_menu(files: list[UploadFile] = File(...)):
 
 # ── /api/knowledge/build-index ────────────────────────────────────────────────
 
-def _run_build_index(job_id: str, incremental: bool):
+def _run_build_index(
+    job_id: str,
+    incremental: bool,
+    batch_size: int | None = None,
+    chunk_batch_size: int | None = None,
+):
     """Run build_index.py in a background thread, capture stdout line by line."""
     job = _jobs[job_id]
     job['status'] = 'running'
@@ -215,6 +220,10 @@ def _run_build_index(job_id: str, incremental: bool):
            '--output', str(INDEXED_DIR)]
     if incremental:
         cmd.append('--incremental')
+    if batch_size is not None:
+        cmd.extend(['--batch-size', str(batch_size)])
+    if chunk_batch_size is not None:
+        cmd.extend(['--chunk-batch-size', str(chunk_batch_size)])
 
     try:
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
@@ -252,6 +261,22 @@ def _run_build_index(job_id: str, incremental: bool):
 @app.post('/api/knowledge/build-index')
 async def build_index(body: dict):
     incremental = body.get('incremental', True)
+    batch_size = body.get('batch_size')
+    chunk_batch_size = body.get('chunk_batch_size')
+
+    if not isinstance(incremental, bool):
+        raise HTTPException(400, 'incremental must be a boolean')
+    if batch_size is not None:
+        if not isinstance(batch_size, int):
+            raise HTTPException(400, 'batch_size must be an integer')
+        if batch_size <= 0:
+            raise HTTPException(400, 'batch_size must be > 0')
+    if chunk_batch_size is not None:
+        if not isinstance(chunk_batch_size, int):
+            raise HTTPException(400, 'chunk_batch_size must be an integer')
+        if chunk_batch_size <= 0:
+            raise HTTPException(400, 'chunk_batch_size must be > 0')
+
     job_id = str(uuid.uuid4())[:8]
     _jobs[job_id] = {
         'status': 'pending',
@@ -260,7 +285,11 @@ async def build_index(body: dict):
         'total_vectors': 0,
         'error': '',
     }
-    t = threading.Thread(target=_run_build_index, args=(job_id, incremental), daemon=True)
+    t = threading.Thread(
+        target=_run_build_index,
+        args=(job_id, incremental, batch_size, chunk_batch_size),
+        daemon=True,
+    )
     t.start()
     return {'job_id': job_id}
 

--- a/web/src/panels/perception/IndexBuilderPanel.css
+++ b/web/src/panels/perception/IndexBuilderPanel.css
@@ -33,3 +33,14 @@
   cursor: pointer;
 }
 .km-checkbox-row input[type="checkbox"] { accent-color: var(--color-info); }
+
+.km-index-builder-panel label > span {
+  display: block;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.km-index-builder-panel input[type="number"] {
+  width: 120px;
+}

--- a/web/src/panels/perception/IndexBuilderPanel.jsx
+++ b/web/src/panels/perception/IndexBuilderPanel.jsx
@@ -33,6 +33,8 @@ function IndexBuilderPanel() {
   const [status, setStatus] = useState('idle');
   const [log, setLog] = useState([]);
   const [incremental, setIncremental] = useState(true);
+  const [batchSize, setBatchSize] = useState(16);
+  const [chunkBatchSize, setChunkBatchSize] = useState(512);
   const [indexInfo, setIndexInfo] = useState(null);
   const pollRef = useRef(null);
   const cursorRef = useRef(0);
@@ -68,7 +70,11 @@ function IndexBuilderPanel() {
       const res = await fetch(`${API}/build-index`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ incremental }),
+        body: JSON.stringify({
+          incremental,
+          batch_size: Number(batchSize),
+          chunk_batch_size: Number(chunkBatchSize),
+        }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.detail ?? res.statusText);
@@ -138,6 +144,27 @@ function IndexBuilderPanel() {
           />
           <span>Incremental (skip unchanged files)</span>
         </label>
+
+        <div className="row row-wrap">
+          <label>
+            <span>Embed batch size</span>
+            <input
+              type="number"
+              min={1}
+              value={batchSize}
+              onChange={(e) => setBatchSize(Math.max(1, Number(e.target.value) || 1))}
+            />
+          </label>
+          <label>
+            <span>Chunk stream batch</span>
+            <input
+              type="number"
+              min={1}
+              value={chunkBatchSize}
+              onChange={(e) => setChunkBatchSize(Math.max(1, Number(e.target.value) || 1))}
+            />
+          </label>
+        </div>
 
         <div className="row row-wrap">
           <button


### PR DESCRIPTION
### Motivation
- Allow tuning of indexing throughput by exposing embed and chunk-stream batch sizes to the index builder workflow.

### Description
- Backend: extended `_run_build_index` to accept `batch_size` and `chunk_batch_size` and append `--batch-size` / `--chunk-batch-size` to the `build_index.py` command when provided, and preserved existing stdout parsing and job status handling.
- Backend: added request validation in `/api/knowledge/build-index` for `incremental`, `batch_size`, and `chunk_batch_size` (types and >0 checks) and pass the values into the background thread.
- Frontend: added numeric inputs to `IndexBuilderPanel` (`batchSize` default 16, `chunkBatchSize` default 512) and send `batch_size` and `chunk_batch_size` in the `POST /api/build-index` body; added small CSS for labels and input sizing.

### Testing
- No automated tests were added or modified for this change and no automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c571afe1a4832cb76909b86cf512a8)