### PR TITLE
Switch follow mode control from topic to SetBool service

### DIFF
--- a/config/ros2_topics.yaml
+++ b/config/ros2_topics.yaml
@@ -358,19 +358,6 @@
       "owner_pkg": "tts_pkg"
     },
     {
-      "topic": "hri/set_follow_mode",
-      "msg_type": "std_msgs/msg/Bool",
-      "publishers": [
-        "hri_manager_node"
-      ],
-      "subscribers": [
-        "person_detection_node"
-      ],
-      "qos": "unknown",
-      "description": "Enable/disable person target registration and follow behavior.",
-      "owner_pkg": "interaction_pkg"
-    },
-    {
       "topic": "hri/manager_state",
       "msg_type": "std_msgs/msg/String",
       "publishers": [
@@ -563,6 +550,20 @@
       "qos": "unknown",
       "description": "Velocity command output to robot base.",
       "owner_pkg": "navigation_pkg"
+    }
+  ],
+  "services": [
+    {
+      "service": "hri/set_follow_mode",
+      "srv_type": "std_srvs/srv/SetBool",
+      "servers": [
+        "person_detection_node"
+      ],
+      "clients": [
+        "hri_manager_node"
+      ],
+      "description": "Enable/disable person target follow mode with explicit success/failure response.",
+      "owner_pkg": "interaction_pkg"
     }
   ]
 }

--- a/docs/dev/nodes.adoc
+++ b/docs/dev/nodes.adoc
@@ -61,9 +61,9 @@ This document is the SSOT for ROS2 node details in the current workspace.
 *Executable*:: `person_detection_node`
 *Language*:: Python
 *Launch*:: `bringup/launch/perception.launch.py`
-*Subscriptions*:: <<topics.adoc#topic-dori-camera-front-color-image-raw,/camera/front/color/image_raw>> (`sensor_msgs/msg/Image`), <<topics.adoc#topic-dori-camera-front-depth-image-raw,/camera/front/depth/image_raw>> (`sensor_msgs/msg/Image`), <<topics.adoc#topic-dori-camera-front-depth-scale,/camera/front/depth/scale>> (`std_msgs/msg/Float32`), <<topics.adoc#topic-dori-hri-set_follow_mode,/hri/set_follow_mode>> (`std_msgs/msg/Bool`)
+*Subscriptions*:: <<topics.adoc#topic-dori-camera-front-color-image-raw,/camera/front/color/image_raw>> (`sensor_msgs/msg/Image`), <<topics.adoc#topic-dori-camera-front-depth-image-raw,/camera/front/depth/image_raw>> (`sensor_msgs/msg/Image`), <<topics.adoc#topic-dori-camera-front-depth-scale,/camera/front/depth/scale>> (`std_msgs/msg/Float32`)
 *Publications*:: <<topics.adoc#topic-dori-hri-persons,/hri/persons>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-hri-interaction_trigger,/hri/interaction_trigger>> (`std_msgs/msg/Bool`), <<topics.adoc#topic-dori-hri-tracking_state,/hri/tracking_state>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-follow-target_offset,/follow/target_offset>> (`geometry_msgs/msg/Point`), <<topics.adoc#topic-dori-hri-annotated_image,/hri/annotated_image>> (`sensor_msgs/msg/Image`)
-*Services (server)*:: -
+*Services (server)*:: <<topics.adoc#service-dori-hri-set_follow_mode,/hri/set_follow_mode>> (`std_srvs/srv/SetBool`)
 *Services (client)*:: -
 *Actions*:: -
 *Parameters*:: See <<parameters.adoc#param-person_detection_node, person_detection_node parameters>>
@@ -144,9 +144,9 @@ This document is the SSOT for ROS2 node details in the current workspace.
 *Language*:: Python
 *Launch*:: `bringup/launch/interaction.launch.py`
 *Subscriptions*:: <<topics.adoc#topic-dori-stt-wake_word_detected,/stt/wake_word_detected>> (`std_msgs/msg/Bool`), <<topics.adoc#topic-dori-stt-result,/stt/result>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-hri-tracking_state,/hri/tracking_state>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-hri-gesture_command,/hri/gesture_command>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-hri-expression_command,/hri/expression_command>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-landmark-context,/landmark/context>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-tts-done,/tts/done>> (`std_msgs/msg/Bool`)
-*Publications*:: <<topics.adoc#topic-dori-hri-set_follow_mode,/hri/set_follow_mode>> (`std_msgs/msg/Bool`), <<topics.adoc#topic-dori-hri-manager-state,/hri/manager_state>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-llm-query,/llm/query>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-tts-text,/tts/text>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-nav-command,/nav/command>> (`std_msgs/msg/String`)
+*Publications*:: <<topics.adoc#topic-dori-hri-manager-state,/hri/manager_state>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-llm-query,/llm/query>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-tts-text,/tts/text>> (`std_msgs/msg/String`), <<topics.adoc#topic-dori-nav-command,/nav/command>> (`std_msgs/msg/String`)
 *Services (server)*:: -
-*Services (client)*:: -
+*Services (client)*:: <<topics.adoc#service-dori-hri-set_follow_mode,/hri/set_follow_mode>> (`std_srvs/srv/SetBool`)
 *Actions*:: -
 *Parameters*:: See <<parameters.adoc#param-hri_manager_node, hri_manager_node parameters>>
 *Lifecycle*:: unmanaged

--- a/docs/dev/parameters.adoc
+++ b/docs/dev/parameters.adoc
@@ -79,7 +79,7 @@ This document is the SSOT for ROS2 parameter details in the current workspace.
 | topics.color_image_sub | string | `/camera/front/color/image_raw` | topic path | - | RGB input topic.
 | topics.depth_image_sub | string | `/camera/front/depth/image_raw` | topic path | - | Depth input topic.
 | topics.depth_scale_sub | string | `/camera/front/depth/scale` | topic path | - | Depth scale input topic.
-| topics.follow_mode_sub | string | `/hri/set_follow_mode` | topic path | - | Follow-mode enable topic.
+| services.follow_mode_service | string | `/hri/set_follow_mode` | service path | - | Follow-mode SetBool service.
 | topics.persons_pub | string | `/hri/persons` | topic path | - | Detected person list topic.
 | topics.interaction_trigger_pub | string | `/hri/interaction_trigger` | topic path | - | Interaction trigger topic.
 | topics.tracking_state_pub | string | `/hri/tracking_state` | topic path | - | Tracking state topic.
@@ -203,7 +203,7 @@ This document is the SSOT for ROS2 parameter details in the current workspace.
 | topics.expression_command_sub | string | `/hri/expression_command` | topic path | - | Expression command input.
 | topics.landmark_context_sub | string | `/landmark/context` | topic path | - | Landmark context input.
 | topics.tts_done_sub | string | `/tts/done` | topic path | - | TTS completion input.
-| topics.follow_mode_pub | string | `/hri/set_follow_mode` | topic path | - | Follow mode control output.
+| services.follow_mode_service | string | `/hri/set_follow_mode` | service path | - | Follow mode SetBool service client target.
 | topics.manager_state_pub | string | `/hri/manager_state` | topic path | - | HRI state output.
 | topics.llm_query_pub | string | `/llm/query` | topic path | - | LLM query output.
 | topics.tts_text_pub | string | `/tts/text` | topic path | - | Direct TTS text output.

--- a/docs/dev/topics.adoc
+++ b/docs/dev/topics.adoc
@@ -510,24 +510,30 @@ NOTE: Rear camera topics use the same schema under `/camera/rear/...` (for examp
 *Description*:: JSON list of detected persons/tracks.
 
 
-[[topic-dori-hri-set_follow_mode]]
-=== /hri/set_follow_mode
+[[service-dori-hri-set_follow_mode]]
+=== /hri/set_follow_mode (service)
 
-*Type (msg)*:: `std_msgs/msg/Bool`
-*Publishers*:: hri_manager_node
-*Subscribers*:: person_detection_node
-*Frequency*:: Expected: N/A, Actual: TBD
-*QoS*:: Reliability: Reliable, Durability: Volatile
-*Flow*:: hri_manager_node → /hri/set_follow_mode → person_detection_node
+*Type (srv)*:: `std_srvs/srv/SetBool`
+*Clients*:: hri_manager_node
+*Servers*:: person_detection_node
+*Flow*:: hri_manager_node → /hri/set_follow_mode (SetBool) → person_detection_node
 
-.Message fields
+.Request fields
 [cols="1,1,1,3",options="header"]
 |===
 | Field | Type | Unit | Description
-| data | TBD | - | See message definition for field-level details.
+| data | bool | - | `true` enables follow mode; `false` disables and releases target.
 |===
 
-*Description*:: Enable/disable person target registration and follow behavior.
+.Response fields
+[cols="1,1,1,3",options="header"]
+|===
+| Field | Type | Unit | Description
+| success | bool | - | Service application result.
+| message | string | - | Human-readable result details.
+|===
+
+*Description*:: Follow mode 제어를 요청하고 success/message로 적용 결과를 즉시 반환한다.
 
 
 [[topic-dori-hri-tracking_state]]
@@ -834,4 +840,3 @@ NOTE: Rear camera topics use the same schema under `/camera/rear/...` (for examp
 |===
 
 *Description*:: Periodic system telemetry for monitoring and diagnostics.
-

--- a/ros2_ws/src/bringup/launch/interaction.launch.py
+++ b/ros2_ws/src/bringup/launch/interaction.launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
             'topics.expression_command_sub': _topic(dori_ns, '/hri/expression_command'),
             'topics.landmark_context_sub': _topic(dori_ns, '/landmark/context'),
             'topics.tts_done_sub': _topic(dori_ns, '/tts/done'),
-            'topics.follow_mode_pub': _topic(dori_ns, '/hri/set_follow_mode'),
+            'services.follow_mode_service': _topic(dori_ns, '/hri/set_follow_mode'),
             'topics.manager_state_pub': _topic(dori_ns, '/hri/manager_state'),
             'topics.llm_query_pub': _topic(dori_ns, '/llm/query'),
             'topics.tts_text_pub': _topic(dori_ns, '/tts/text'),

--- a/ros2_ws/src/bringup/launch/perception.launch.py
+++ b/ros2_ws/src/bringup/launch/perception.launch.py
@@ -143,7 +143,7 @@ def generate_launch_description():
             'topics.color_image_sub': _topic(dori_ns, '/camera/front/color/image_raw'),
             'topics.depth_image_sub': _topic(dori_ns, '/camera/front/depth/image_raw'),
             'topics.depth_scale_sub': _topic(dori_ns, '/camera/front/depth/scale'),
-            'topics.follow_mode_sub': _topic(dori_ns, '/hri/set_follow_mode'),
+            'services.follow_mode_service': _topic(dori_ns, '/hri/set_follow_mode'),
             'topics.persons_pub': _topic(dori_ns, '/hri/persons'),
             'topics.interaction_trigger_pub': _topic(dori_ns, '/hri/interaction_trigger'),
             'topics.tracking_state_pub': _topic(dori_ns, '/hri/tracking_state'),

--- a/ros2_ws/src/interaction_pkg/interaction_pkg/hri_manager_node.py
+++ b/ros2_ws/src/interaction_pkg/interaction_pkg/hri_manager_node.py
@@ -13,11 +13,13 @@ Subscribe topics:
   tts/done                 (Bool)   - TTS playback finished
 
 Publish topics:
-  hri/set_follow_mode      (Bool)   - enable/disable person following
   hri/manager_state        (String) - current HRI state (1 Hz)
   llm/query                (String) - query + context sent to LLM node
   tts/text                 (String) - direct TTS output (bypass LLM)
   nav/command              (String) - high-level navigation command
+
+Service clients:
+  hri/set_follow_mode      (SetBool) - enable/disable person following
 
 State machine:
   IDLE        - waiting for wake word
@@ -32,6 +34,7 @@ from enum import Enum
 
 import rclpy
 from rclpy.node import Node
+from std_srvs.srv import SetBool
 from std_msgs.msg import Bool, String
 
 
@@ -56,7 +59,7 @@ class HRIManagerNode(Node):
         self.declare_parameter('topics.expression_command_sub', 'hri/expression_command')
         self.declare_parameter('topics.landmark_context_sub', 'landmark/context')
         self.declare_parameter('topics.tts_done_sub', 'tts/done')
-        self.declare_parameter('topics.follow_mode_pub', 'hri/set_follow_mode')
+        self.declare_parameter('services.follow_mode_service', 'hri/set_follow_mode')
         self.declare_parameter('topics.manager_state_pub', 'hri/manager_state')
         self.declare_parameter('topics.llm_query_pub', 'llm/query')
         self.declare_parameter('topics.tts_text_pub', 'tts/text')
@@ -78,7 +81,7 @@ class HRIManagerNode(Node):
         expression_command_topic = self.get_parameter('topics.expression_command_sub').value
         landmark_context_topic = self.get_parameter('topics.landmark_context_sub').value
         tts_done_topic = self.get_parameter('topics.tts_done_sub').value
-        follow_mode_topic = self.get_parameter('topics.follow_mode_pub').value
+        follow_mode_service = self.get_parameter('services.follow_mode_service').value
         manager_state_topic = self.get_parameter('topics.manager_state_pub').value
         llm_query_topic = self.get_parameter('topics.llm_query_pub').value
         tts_text_topic = self.get_parameter('topics.tts_text_pub').value
@@ -101,11 +104,11 @@ class HRIManagerNode(Node):
             Bool, tts_done_topic, self._on_tts_done, 10)
 
         # Publishers
-        self.follow_mode_pub = self.create_publisher(Bool, follow_mode_topic, 10)
         self.manager_state_pub = self.create_publisher(String, manager_state_topic, 10)
         self.llm_query_pub = self.create_publisher(String, llm_query_topic, 10)
         self.tts_pub = self.create_publisher(String, tts_text_topic, 10)
         self.nav_command_pub = self.create_publisher(String, nav_command_topic, 10)
+        self.follow_mode_client = self.create_client(SetBool, follow_mode_service)
 
         # State publish timer (1 Hz)
         self.create_timer(1.0, self._publish_state)
@@ -269,10 +272,31 @@ class HRIManagerNode(Node):
         self.get_logger().info(f'LLM query: "{user_text[:40]}"')
 
     def _set_follow_mode(self, enable: bool):
-        msg = Bool()
-        msg.data = enable
-        self.follow_mode_pub.publish(msg)
-        self.get_logger().info(f'Follow mode: {"ON" if enable else "OFF"}')
+        if not self.follow_mode_client.wait_for_service(timeout_sec=1.0):
+            self.get_logger().error('Follow mode service unavailable')
+            return
+
+        req = SetBool.Request()
+        req.data = enable
+        future = self.follow_mode_client.call_async(req)
+        future.add_done_callback(
+            lambda done: self._on_follow_mode_response(done, enable)
+        )
+
+    def _on_follow_mode_response(self, future, requested_enable: bool):
+        try:
+            res = future.result()
+        except Exception as exc:
+            self.get_logger().error(
+                f'Follow mode {"ON" if requested_enable else "OFF"} failed: {exc}'
+            )
+            return
+
+        level = self.get_logger().info if res.success else self.get_logger().warn
+        level(
+            f'Follow mode {"ON" if requested_enable else "OFF"} '
+            f'{"succeeded" if res.success else "failed"}: {res.message}'
+        )
 
     def _nav_command(self, command: str, **kwargs):
         payload = {'command': command, **kwargs, 'timestamp': time.time()}

--- a/ros2_ws/src/interaction_pkg/package.xml
+++ b/ros2_ws/src/interaction_pkg/package.xml
@@ -9,6 +9,7 @@
 
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2_ws/src/perception_pkg/package.xml
+++ b/ros2_ws/src/perception_pkg/package.xml
@@ -10,6 +10,7 @@
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>geometry_msgs</depend>
   <depend>cv_bridge</depend>
 

--- a/ros2_ws/src/perception_pkg/perception_pkg/person_detection_node.py
+++ b/ros2_ws/src/perception_pkg/perception_pkg/person_detection_node.py
@@ -11,6 +11,7 @@ from geometry_msgs.msg import Point
 from rclpy.node import Node
 from sensor_msgs.msg import Image
 from std_msgs.msg import Bool, Float32, String
+from std_srvs.srv import SetBool
 
 try:
     from ultralytics import YOLO
@@ -42,7 +43,7 @@ class PersonDetectionNode(Node):
         self.declare_parameter('topics.color_image_sub', 'camera/front/color/image_raw')
         self.declare_parameter('topics.depth_image_sub', 'camera/front/depth/image_raw')
         self.declare_parameter('topics.depth_scale_sub', 'camera/front/depth/scale')
-        self.declare_parameter('topics.follow_mode_sub', 'hri/set_follow_mode')
+        self.declare_parameter('services.follow_mode_service', 'hri/set_follow_mode')
         self.declare_parameter('topics.persons_pub', 'hri/persons')
         self.declare_parameter('topics.interaction_trigger_pub', 'hri/interaction_trigger')
         self.declare_parameter('topics.tracking_state_pub', 'hri/tracking_state')
@@ -94,7 +95,7 @@ class PersonDetectionNode(Node):
         color_image_topic = self.get_parameter('topics.color_image_sub').value
         depth_image_topic = self.get_parameter('topics.depth_image_sub').value
         depth_scale_topic = self.get_parameter('topics.depth_scale_sub').value
-        follow_mode_topic = self.get_parameter('topics.follow_mode_sub').value
+        follow_mode_service = self.get_parameter('services.follow_mode_service').value
         persons_topic = self.get_parameter('topics.persons_pub').value
         interaction_trigger_topic = self.get_parameter('topics.interaction_trigger_pub').value
         tracking_state_topic = self.get_parameter('topics.tracking_state_pub').value
@@ -110,8 +111,8 @@ class PersonDetectionNode(Node):
             self.create_subscription(
                 Float32, depth_scale_topic,
                 lambda msg: setattr(self, '_depth_scale', msg.data), 10)
-        self.create_subscription(
-            Bool, follow_mode_topic, self._follow_mode_callback, 10)
+        self.create_service(
+            SetBool, follow_mode_service, self._follow_mode_service_callback)
 
         # Publishers
         self.persons_detail_pub = self.create_publisher(String, persons_topic, 10)
@@ -129,12 +130,18 @@ class PersonDetectionNode(Node):
         except Exception as e:
             self.get_logger().error(f'Failed to convert depth image: {e}')
 
-    def _follow_mode_callback(self, msg: Bool):
-        if msg.data:
+    def _follow_mode_service_callback(self, request: SetBool.Request, response: SetBool.Response):
+        if request.data:
             self._pending_register = True
-            self.get_logger().info('Request follow mode — register target in next frame')
+            response.success = True
+            response.message = 'Follow mode enable accepted (target will be registered on next frame)'
+            self.get_logger().info('Follow mode service request ON — register target in next frame')
         else:
             self._release_target('Unfollow by external command')
+            response.success = True
+            response.message = 'Follow mode disabled and target released'
+
+        return response
 
     def image_callback(self, msg: Image):
         try:


### PR DESCRIPTION
### Motivation
- Move follow-mode control from a fire-and-forget topic to a `std_srvs/srv/SetBool` service so the caller can receive immediate success/failure feedback when enabling/disabling follow mode.

### Description
- Replace the `/hri/set_follow_mode` publish/subscribe flow with a `SetBool` service client in `hri_manager_node` and a `SetBool` service server in `person_detection_node`, using the `services.follow_mode_service` parameter to supply the name.
- Implement asynchronous service call handling in `hri_manager_node` and log apply `success`/`message` from the service response via `_on_follow_mode_response`.
- Implement `follow_mode` service handler in `person_detection_node` which sets `_pending_register` when request is `true`, releases target when `false`, and returns `response.success`/`response.message` accordingly.
- Update launch parameters (`interaction.launch.py` and `perception.launch.py`) to use `services.follow_mode_service`, add `std_srvs` dependency to `interaction_pkg` and `perception_pkg` `package.xml`, and migrate documentation and `config/ros2_topics.yaml` entries from a topic entry to a `services` section and service docs (`docs/dev/parameters.adoc`, `docs/dev/topics.adoc`, `docs/dev/nodes.adoc`).

### Testing
- `python3 -m compileall ros2_ws/src/interaction_pkg/interaction_pkg/hri_manager_node.py ros2_ws/src/perception_pkg/perception_pkg/person_detection_node.py` completed successfully.
- `python3 tools/topic/topic_lint.py --check` completed successfully and emitted repository-specific warnings about topic/service drift (warning-only output expected in current repo state).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdb9c3f724832c8f77b0e8ea728354)