### PR TITLE
Add preemption guards and safe terminal transitions in navigator execute callback

### DIFF
--- a/ros2_ws/src/navigation_pkg/navigation_pkg/navigator.py
+++ b/ros2_ws/src/navigation_pkg/navigation_pkg/navigator.py
@@ -141,53 +141,83 @@ class NavigatorNode(Node):
         self._plan_global_path()
 
         result = Navigate.Result()
-        while rclpy.ok():
-            if goal_handle.is_cancel_requested:
-                self.get_logger().info('Navigation canceled by client')
+        try:
+            while rclpy.ok():
                 with self.state_lock:
-                    self._stop_robot()
-                    self.state = NavigationState.IDLE
-                    self.current_goal = None
-                goal_handle.canceled()
-                result.code = Navigate.Result.CANCELED
-                result.message = 'Navigation canceled'
-                return result
+                    is_current_goal = self.active_goal_handle is goal_handle
+                    is_goal_active = goal_handle.is_active
 
+                if not is_current_goal or not is_goal_active:
+                    self.get_logger().info(
+                        'Ending execute loop for goal due to preemption/state change: '
+                        f'is_current_goal={is_current_goal}, is_goal_active={is_goal_active}'
+                    )
+                    result.code = Navigate.Result.INVALID_STATE
+                    result.message = 'Preempted by newer goal'
+                    return result
+
+                if goal_handle.is_cancel_requested:
+                    self.get_logger().info('Navigation canceled by client')
+                    with self.state_lock:
+                        self._stop_robot()
+                        self.state = NavigationState.IDLE
+                        self.current_goal = None
+                    if not goal_handle.is_active:
+                        result.code = Navigate.Result.INVALID_STATE
+                        result.message = 'Goal became inactive before cancel transition'
+                        return result
+                    goal_handle.canceled()
+                    result.code = Navigate.Result.CANCELED
+                    result.message = 'Navigation canceled'
+                    return result
+
+                with self.state_lock:
+                    state = self.state
+                    distance = self._distance_to_goal()
+
+                feedback = Navigate.Feedback()
+                feedback.distance_remaining = float(distance)
+                feedback.state = state.name
+                feedback.status_message = self._state_to_status(state)
+                goal_handle.publish_feedback(feedback)
+
+                if state == NavigationState.GOAL_REACHED:
+                    with self.state_lock:
+                        self._stop_robot()
+                        self.state = NavigationState.IDLE
+                        self.current_goal = None
+                    if not goal_handle.is_active:
+                        result.code = Navigate.Result.INVALID_STATE
+                        result.message = 'Goal became inactive before succeed transition'
+                        return result
+                    goal_handle.succeed()
+                    result.code = Navigate.Result.SUCCESS
+                    result.message = 'Goal reached'
+                    return result
+
+                if state == NavigationState.FAILED:
+                    with self.state_lock:
+                        self._stop_robot()
+                        self.state = NavigationState.IDLE
+                        self.current_goal = None
+                    if not goal_handle.is_active:
+                        result.code = Navigate.Result.INVALID_STATE
+                        result.message = 'Goal became inactive before abort transition'
+                        return result
+                    goal_handle.abort()
+                    result.code = Navigate.Result.PLANNING_FAILED
+                    result.message = 'Navigation failed'
+                    return result
+
+                time.sleep(0.2)
+
+            result.code = Navigate.Result.INVALID_STATE
+            result.message = 'Navigation interrupted by shutdown'
+            return result
+        finally:
             with self.state_lock:
-                state = self.state
-                distance = self._distance_to_goal()
-
-            feedback = Navigate.Feedback()
-            feedback.distance_remaining = float(distance)
-            feedback.state = state.name
-            feedback.status_message = self._state_to_status(state)
-            goal_handle.publish_feedback(feedback)
-
-            if state == NavigationState.GOAL_REACHED:
-                with self.state_lock:
-                    self._stop_robot()
-                    self.state = NavigationState.IDLE
-                    self.current_goal = None
-                goal_handle.succeed()
-                result.code = Navigate.Result.SUCCESS
-                result.message = 'Goal reached'
-                return result
-
-            if state == NavigationState.FAILED:
-                with self.state_lock:
-                    self._stop_robot()
-                    self.state = NavigationState.IDLE
-                    self.current_goal = None
-                goal_handle.abort()
-                result.code = Navigate.Result.PLANNING_FAILED
-                result.message = 'Navigation failed'
-                return result
-
-            time.sleep(0.2)
-
-        result.code = Navigate.Result.INVALID_STATE
-        result.message = 'Navigation interrupted by shutdown'
-        return result
+                if self.active_goal_handle is goal_handle:
+                    self.active_goal_handle = None
 
     def odom_callback(self, msg: Odometry):
         pose = PoseStamped()


### PR DESCRIPTION
### Motivation
- Prevent race conditions and spurious transitions when multiple goals are submitted concurrently by ensuring the executing loop only continues for the currently active and active `goal_handle`.
- Make terminal transitions (`canceled()`, `succeed()`, `abort()`) defensive to avoid calling them on inactive handles.
- Ensure the shared `self.active_goal_handle` state is not clobbered by an older callback when a newer goal becomes active.

### Description
- Added an early-loop preemption guard in `NavigatorNode.execute_navigate_callback` that checks `self.active_goal_handle is goal_handle` and `goal_handle.is_active`, logging and returning `INVALID_STATE` with message `Preempted by newer goal` if the checks fail.
- Kept assignment `self.active_goal_handle = goal_handle` when accepting a new goal so prior execute loops will self-terminate via the new guard.
- Added `goal_handle.is_active` checks immediately before calling `goal_handle.canceled()`, `goal_handle.succeed()`, and `goal_handle.abort()` to skip transitions on inactive handles.
- Moved active-goal cleanup into a `finally` block and reset `self.active_goal_handle = None` only when `self.active_goal_handle is goal_handle` to avoid overwriting a newly active goal, and added informational logging when the loop exits due to preemption/state change.
- Modified file: `ros2_ws/src/navigation_pkg/navigation_pkg/navigator.py`.

### Testing
- Ran `python -m py_compile ros2_ws/src/navigation_pkg/navigation_pkg/navigator.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf21ff26c832c87c28a7a22aa27f3)