### PR TITLE
Harden Knowledge API CORS configuration and origin enforcement

### DIFF
--- a/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
+++ b/ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py
@@ -122,11 +122,48 @@ _crawl_jobs: dict[str, dict] = {}
 app = FastAPI(title='DORI Knowledge API', version='1.0.0')
 logger = logging.getLogger(__name__)
 
+_DEFAULT_ALLOWED_ORIGINS = (
+    'https://dash.dgist-dori.xyz',
+)
+
+
+def _parse_allowed_origins(raw: str) -> list[str]:
+    if not raw:
+        return list(_DEFAULT_ALLOWED_ORIGINS)
+
+    origins: list[str] = []
+    for item in (part.strip() for part in raw.split(',') if part.strip()):
+        normalized = item.rstrip('/')
+        if normalized and normalized not in origins:
+            origins.append(normalized)
+    return origins or list(_DEFAULT_ALLOWED_ORIGINS)
+
+
+_ALLOWED_ORIGINS = _parse_allowed_origins(os.environ.get('DORI_ALLOWED_ORIGINS', '').strip())
+_ALLOWED_ORIGIN_SET = set(_ALLOWED_ORIGINS)
+
+
+@app.middleware('http')
+async def enforce_origin_allowlist(request: Request, call_next):
+    origin = request.headers.get('origin', '').strip().rstrip('/')
+    if origin and origin not in _ALLOWED_ORIGIN_SET:
+        logger.warning(
+            'cors_origin_blocked origin=%s path=%s method=%s client=%s',
+            origin,
+            request.url.path,
+            request.method,
+            request.client.host if request.client else '-',
+        )
+        return JSONResponse(status_code=403, content={'detail': 'Origin is not allowed'})
+    return await call_next(request)
+
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=['*'],
-    allow_methods=['*'],
-    allow_headers=['*'],
+    allow_origins=_ALLOWED_ORIGINS,
+    allow_credentials=False,
+    allow_methods=['GET', 'POST', 'PUT', 'OPTIONS'],
+    allow_headers=['Authorization', 'Content-Type'],
 )
 
 


### PR DESCRIPTION
### Motivation
- Remove the existing permissive CORS wildcard and restrict cross-origin access to a controlled allowlist to reduce risk of unwanted dashboard origins accessing the API.
- Provide an environment-driven allowlist so deployments can configure dashboard domains without code changes.
- Align CORS settings with credential policy by disabling credentialed cross-site requests and minimizing allowed methods and headers.
- Ensure disallowed Origin attempts are logged for incident visibility and debugging.

### Description
- Replace `allow_origins=['*']` with an allowlist parsed from the `DORI_ALLOWED_ORIGINS` environment variable using `_parse_allowed_origins`, defaulting to `https://dash.dgist-dori.xyz` when unset or invalid.
- Add an `_ALLOWED_ORIGIN_SET` and an HTTP middleware `enforce_origin_allowlist` that returns `403` and emits a `cors_origin_blocked` warning log when `Origin` is present but not allowlisted.
- Configure `CORSMiddleware` to use the parsed allowlist, set `allow_credentials=False`, limit `allow_methods` to `['GET', 'POST', 'PUT', 'OPTIONS']`, and restrict `allow_headers` to `['Authorization', 'Content-Type']`.
- Normalize trailing slashes and deduplicate entries when parsing `DORI_ALLOWED_ORIGINS` to avoid common configuration mistakes.

### Testing
- Ran `python3 -m py_compile ros2_ws/src/dashboard_pkg/dashboard_pkg/knowledge_api.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce015e7db8832ca71003af05d17cc1)