### PR TITLE
Configurable STT audio input topic and wav_pcm16 topic-mode for STT node

### DIFF
--- a/config/ros2_topics.yaml
+++ b/config/ros2_topics.yaml
@@ -332,17 +332,30 @@
       "owner_pkg": "perception_pkg"
     },
     {
+      "topic": "stt/audio_input",
+      "msg_type": "std_msgs/msg/String",
+      "publishers": [
+        "dashboard STTPanel mic publisher"
+      ],
+      "subscribers": [
+        "stt_node"
+      ],
+      "qos": "unknown",
+      "description": "E2E STT input payload JSON: {audio_b64, format:'wav_pcm16', sample_rate:16000, channels:1}.",
+      "owner_pkg": "stt_pkg"
+    },
+    {
       "topic": "stt/result",
       "msg_type": "std_msgs/msg/String",
       "publishers": [
-        "external STT node"
+        "stt_node"
       ],
       "subscribers": [
         "hri_manager_node"
       ],
       "qos": "unknown",
-      "description": "User transcription JSON/text from speech recognizer.",
-      "owner_pkg": "external"
+      "description": "STT output JSON/text from recognizer. E2E path: STTPanel mic -> stt/audio_input -> stt_node(Whisper) -> stt/result -> hri_manager_node.",
+      "owner_pkg": "stt_pkg"
     },
     {
       "topic": "tts/done",

--- a/ros2_ws/src/bringup/launch/voice.launch.py
+++ b/ros2_ws/src/bringup/launch/voice.launch.py
@@ -24,6 +24,7 @@ def generate_launch_description():
         DeclareLaunchArgument('whisper_device', default_value='cpu'),
         DeclareLaunchArgument('wake_word', default_value='porcupine'),
         DeclareLaunchArgument('wake_word_paths', default_value=''),
+        DeclareLaunchArgument('stt_audio_input_mode', default_value='microphone'),
         DeclareLaunchArgument('tts_engine', default_value='gtts'),
         DeclareLaunchArgument('tts_language', default_value='ko'),
         DeclareLaunchArgument('namespace', default_value='/dori'),
@@ -41,9 +42,11 @@ def generate_launch_description():
             'whisper_device': LaunchConfiguration('whisper_device'),
             'vad_threshold': 0.5,
             'silence_duration': 1.2,
+            'audio_input_mode': LaunchConfiguration('stt_audio_input_mode'),
             'topics.wake_word_pub': _topic(dori_ns, '/stt/wake_word_detected'),
             'topics.result_pub': _topic(dori_ns, '/stt/result'),
             'topics.tts_speaking_sub': _topic(dori_ns, '/tts/speaking'),
+            'topics.audio_input_sub': _topic(dori_ns, '/stt/audio_input'),
         }],
     )
 

--- a/ros2_ws/src/stt_pkg/stt_pkg/stt_node.py
+++ b/ros2_ws/src/stt_pkg/stt_pkg/stt_node.py
@@ -19,6 +19,8 @@ import queue
 import struct
 import threading
 import time
+import wave
+from io import BytesIO
 from pathlib import Path
 
 import numpy as np
@@ -108,6 +110,8 @@ class STTNode(Node):
         self.declare_parameter('topics.wake_word_pub', 'stt/wake_word_detected')
         self.declare_parameter('topics.result_pub', 'stt/result')
         self.declare_parameter('topics.tts_speaking_sub', 'tts/speaking')
+        self.declare_parameter('topics.audio_input_sub', 'stt/audio_input')
+        self.declare_parameter('audio_input_mode', 'microphone')
 
         wake_word        = self.get_parameter('wake_word').value
         wake_word_paths  = self.get_parameter('wake_word_paths').value
@@ -120,6 +124,8 @@ class STTNode(Node):
         wake_word_topic = self.get_parameter('topics.wake_word_pub').value
         result_topic = self.get_parameter('topics.result_pub').value
         tts_speaking_topic = self.get_parameter('topics.tts_speaking_sub').value
+        audio_input_topic = self.get_parameter('topics.audio_input_sub').value
+        self.audio_input_mode = self.get_parameter('audio_input_mode').value
 
         # Publishers
         self.wake_word_pub = self.create_publisher(Bool, wake_word_topic, 10)
@@ -128,6 +134,8 @@ class STTNode(Node):
         # Subscribers
         self.create_subscription(
             Bool, tts_speaking_topic, self._on_tts_speaking, 10)
+        self.create_subscription(
+            String, audio_input_topic, self._on_audio_input_topic, 10)
 
         # State
         self.state           = STTState.IDLE
@@ -236,19 +244,24 @@ class STTNode(Node):
             return
 
         # Audio stream
-        try:
-            self.stream = sd.RawInputStream(
-                samplerate=SAMPLE_RATE,
-                blocksize=FRAME_LENGTH,
-                dtype='int16',
-                channels=CHANNELS,
-                callback=self._audio_callback,
+        if self.audio_input_mode == 'microphone':
+            try:
+                self.stream = sd.RawInputStream(
+                    samplerate=SAMPLE_RATE,
+                    blocksize=FRAME_LENGTH,
+                    dtype='int16',
+                    channels=CHANNELS,
+                    callback=self._audio_callback,
+                )
+                self.stream.start()
+                self.get_logger().info('Audio stream started')
+            except Exception as e:
+                self.get_logger().error(f'Audio stream failed: {e}')
+                return
+        else:
+            self.get_logger().info(
+                f'Audio input mode is "{self.audio_input_mode}" - microphone capture disabled'
             )
-            self.stream.start()
-            self.get_logger().info('Audio stream started')
-        except Exception as e:
-            self.get_logger().error(f'Audio stream failed: {e}')
-            return
 
         # Processing timer (20 Hz)
         self.create_timer(0.05, self._process_audio)
@@ -296,6 +309,40 @@ class STTNode(Node):
 
         except Exception as e:
             self.get_logger().error(f'Audio callback error: {e}')
+
+    def _on_audio_input_topic(self, msg: String):
+        if self.robot_speaking:
+            return
+        if self.audio_input_mode != 'topic':
+            return
+        try:
+            import base64
+            payload = json.loads(msg.data)
+            fmt = payload.get('format')
+            if fmt != 'wav_pcm16':
+                self.get_logger().warn(f'Unsupported audio format: {fmt}')
+                return
+            audio_b64 = payload.get('audio_b64')
+            if not audio_b64:
+                return
+            wav_bytes = base64.b64decode(audio_b64)
+            with wave.open(BytesIO(wav_bytes), 'rb') as wf:
+                sr = wf.getframerate()
+                ch = wf.getnchannels()
+                width = wf.getsampwidth()
+                raw = wf.readframes(wf.getnframes())
+            if sr != SAMPLE_RATE or ch != 1 or width != 2:
+                self.get_logger().warn(
+                    f'Audio spec mismatch (sr={sr}, ch={ch}, width={width * 8}bit). '
+                    f'Expected {SAMPLE_RATE}Hz mono 16-bit PCM.'
+                )
+                return
+            audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+            self.buffer = [audio]
+            self._transcribe()
+            self.buffer.clear()
+        except Exception as e:
+            self.get_logger().error(f'Audio topic decode/transcribe failed: {e}')
 
     # Audio processing (timer callback)
     def _process_audio(self):

--- a/web/src/core/i18n.js
+++ b/web/src/core/i18n.js
@@ -146,7 +146,7 @@ const TRANSLATIONS = {
     // HRI / Perception panel texts
     'panel.tts.placeholder': 'Text for robot speech (e.g. Hello, I am DORI.)',
     'panel.stt.placeholder': 'Enter a test utterance (e.g. Where is the library?)',
-    'panel.stt.hint': 'Recorded audio is published to /dori/debug/audio_blob. Subscribe on Jetson and pass to Whisper for end-to-end STT testing.',
+    'panel.stt.hint': 'Mic audio is published as wav_pcm16 (16 kHz mono) to the configured STT input topic. Set voice.launch.py stt_audio_input_mode=topic to run the real STT pipeline test.',
     'panel.wakeword.hint': 'HRI Manager only reacts in IDLE. You can test the LISTENING → RESPONDING → IDLE cycle.',
     'panel.llm.query.placeholder': 'Question (e.g. Where is the student cafeteria?)',
     'panel.llm.location.placeholder': 'e.g. In front of Building E7',
@@ -251,7 +251,7 @@ const TRANSLATIONS = {
     // HRI / Perception panel texts
     'panel.tts.placeholder': '로봇이 말할 텍스트 (예: 안녕하세요, 도리입니다.)',
     'panel.stt.placeholder': '테스트할 발화를 입력하세요 (예: 도서관 어디야)',
-    'panel.stt.hint': '녹음된 오디오는 /dori/debug/audio_blob으로 publish됩니다. Jetson 측에서 이 토픽을 구독해 Whisper로 전달하면 실제 STT 테스트가 가능합니다.',
+    'panel.stt.hint': '마이크 오디오는 설정된 STT 입력 토픽으로 wav_pcm16(16kHz mono) 포맷으로 publish됩니다. voice.launch.py에서 stt_audio_input_mode=topic으로 설정하면 실제 STT 파이프라인 테스트가 가능합니다.',
     'panel.wakeword.hint': 'HRI Manager가 IDLE일 때만 반응합니다. LISTENING → RESPONDING → IDLE 사이클을 테스트할 수 있습니다.',
     'panel.llm.query.placeholder': '질문 (예: 학생식당 어디에 있어요?)',
     'panel.llm.location.placeholder': '예: E7 건물 앞',

--- a/web/src/panels/hri/STTPanel.jsx
+++ b/web/src/panels/hri/STTPanel.jsx
@@ -8,6 +8,7 @@ import './STTPanel.css';
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const SAMPLE_RATE   = 16000;   // Whisper expects 16 kHz
+const DEFAULT_STT_AUDIO_TOPIC = '/dori/stt/audio_input';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -46,6 +47,7 @@ function STTPanel() {
   const [lang,          setLang]          = useState('auto');
   const [conf,          setConf]          = useState('0.95');
   const [lastResult,    setLastResult]    = useState(null);
+  const [micTopic,      setMicTopic]      = useState(DEFAULT_STT_AUDIO_TOPIC);
 
   // Mic state
   const [micAvail,      setMicAvail]      = useState(false);
@@ -111,26 +113,65 @@ function STTPanel() {
     setMicStatus('processing');
   }
 
-  // After recording stops: build a fake STT result from audio blob
-  // (Actual transcription happens on Jetson. Here we publish a placeholder
-  //  that tells the team mic input worked, with audio length info.)
-  function handleMicStop() {
-    const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+  // After recording stops: encode as WAV PCM16 (16k mono) and publish to STT input topic.
+  async function handleMicStop() {
+    const blob = new Blob(chunksRef.current, { type: 'audio/webm;codecs=opus' });
     const durationEstSec = (chunksRef.current.length * 200) / 1000;
-
-    // Convert to base64 and publish as a custom diagnostic topic
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const b64 = reader.result.split(',')[1];
-      // Publish audio blob to a debug topic (ros-side can optionally pipe to Whisper)
-      pub('/dori/debug/audio_blob', 'std_msgs/msg/String', {
-        data: JSON.stringify({ audio_b64: b64, mime: 'audio/webm', duration_est_sec: durationEstSec }),
+    try {
+      const wavB64 = await toWavBase64(blob);
+      pub(micTopic, 'std_msgs/msg/String', {
+        data: JSON.stringify({
+          audio_b64: wavB64, format: 'wav_pcm16', sample_rate: SAMPLE_RATE, channels: 1, duration_est_sec: durationEstSec,
+        }),
       });
-      addLog(LOG_TAGS.STT, `[mic] audio captured ~${durationEstSec.toFixed(1)}s — published to /dori/debug/audio_blob`);
+      addLog(LOG_TAGS.STT, `[mic] audio captured ~${durationEstSec.toFixed(1)}s — published to ${micTopic} (wav_pcm16)`);
+    } catch (e) {
+      setMicError(`오디오 변환 실패: ${e.message}`);
+    } finally {
       setMicStatus('idle');
-    };
-    reader.readAsDataURL(blob);
+    }
     chunksRef.current = [];
+  }
+
+  async function toWavBase64(blob) {
+    const arrayBuffer = await blob.arrayBuffer();
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    const audioCtx = new AudioCtx({ sampleRate: SAMPLE_RATE });
+    const decoded = await audioCtx.decodeAudioData(arrayBuffer);
+    const mono = decoded.numberOfChannels > 1 ? mixDownToMono(decoded) : decoded.getChannelData(0);
+    const pcm16 = floatTo16BitPCM(mono);
+    const wavBytes = buildWavBytes(pcm16, SAMPLE_RATE, 1);
+    await audioCtx.close();
+    return btoa(String.fromCharCode(...wavBytes));
+  }
+
+  function mixDownToMono(audioBuffer) {
+    const out = new Float32Array(audioBuffer.length);
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch += 1) {
+      const data = audioBuffer.getChannelData(ch);
+      for (let i = 0; i < data.length; i += 1) out[i] += data[i] / audioBuffer.numberOfChannels;
+    }
+    return out;
+  }
+  function floatTo16BitPCM(input) {
+    const out = new Int16Array(input.length);
+    for (let i = 0; i < input.length; i += 1) {
+      const s = Math.max(-1, Math.min(1, input[i]));
+      out[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
+    }
+    return out;
+  }
+  function buildWavBytes(pcm16, sampleRate, channels) {
+    const buffer = new ArrayBuffer(44 + pcm16.length * 2);
+    const view = new DataView(buffer);
+    const writeStr = (offset, str) => { for (let i = 0; i < str.length; i += 1) view.setUint8(offset + i, str.charCodeAt(i)); };
+    writeStr(0, 'RIFF'); view.setUint32(4, 36 + pcm16.length * 2, true); writeStr(8, 'WAVE');
+    writeStr(12, 'fmt '); view.setUint32(16, 16, true); view.setUint16(20, 1, true);
+    view.setUint16(22, channels, true); view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * channels * 2, true); view.setUint16(32, channels * 2, true); view.setUint16(34, 16, true);
+    writeStr(36, 'data'); view.setUint32(40, pcm16.length * 2, true);
+    let off = 44; for (let i = 0; i < pcm16.length; i += 1, off += 2) view.setInt16(off, pcm16[i], true);
+    return new Uint8Array(buffer);
   }
 
   return (
@@ -174,7 +215,13 @@ function STTPanel() {
         </div>
       )}
 
-      <SectionLabel>Microphone → /dori/debug/audio_blob</SectionLabel>
+      <SectionLabel>Microphone → STT Input Topic</SectionLabel>
+      <div className="row row-wrap">
+        <div className="field" style={{ minWidth: 280 }}>
+          <label className="field-label">Mic Publish Topic</label>
+          <input className="input" value={micTopic} onChange={e => setMicTopic(e.target.value)} />
+        </div>
+      </div>
 
       <div className="row">
         <Badge ok={micAvail} label={micAvail ? 'Mic available' : 'Mic unavailable'} />


### PR DESCRIPTION
### Motivation
- Replace the previous debug-only microphone publish flow with a configurable, end-to-end STT input path so the dashboard can be used to test the real STT pipeline. 
- Expose STT node parameters to allow the voice stack to accept audio over a ROS topic (topic-mode) in addition to local microphone capture. 
- Unify the audio payload format to an explicit, compatible format (`wav_pcm16` 16 kHz mono) to avoid mismatches between browser and Jetson/Whisper expectations. 

### Description
- Updated the dashboard STT panel (`web/src/panels/hri/STTPanel.jsx`) to publish mic audio as base64 WAV PCM16 (16 kHz mono) to a configurable topic (default `/dori/stt/audio_input`) and added a `Mic Publish Topic` input in the UI. 
- Implemented client-side conversion from `MediaRecorder` (`webm/opus`) to WAV PCM16 bytes and publish payload JSON with fields `audio_b64`, `format:'wav_pcm16'`, `sample_rate:16000`, and `channels:1`. 
- Added STT node parameters and wiring in `ros2_ws/src/stt_pkg/stt_pkg/stt_node.py`: `topics.audio_input_sub`, `audio_input_mode` and a `String` subscription handler that decodes `wav_pcm16` payloads, validates sample rate/channels/bitwidth, and runs transcription via the existing Whisper pipeline when `audio_input_mode=='topic'`. 
- Exposed `stt_audio_input_mode` launch argument and connected `topics.audio_input_sub`/`audio_input_mode` in `ros2_ws/src/bringup/launch/voice.launch.py`. 
- Registered `stt/audio_input` in `config/ros2_topics.yaml` and updated the `stt/result` entry to document the E2E path (`STTPanel mic -> stt/audio_input -> stt_node -> stt/result -> hri_manager_node`). 
- Replaced the UI hint text in `web/src/core/i18n.js` to describe real STT pipeline testing and the new topic/format expectations. 

### Testing
- Ran `python3 -m py_compile ros2_ws/src/stt_pkg/stt_pkg/stt_node.py` and it completed successfully. 
- Ran `python3 -m py_compile ros2_ws/src/bringup/launch/voice.launch.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c470cf3c832ca647670c3ca65497)