### PR TITLE
Add one‑click Conversation E2E test to Home dashboard

### DIFF
--- a/web/src/tabs/HomeTab.css
+++ b/web/src/tabs/HomeTab.css
@@ -140,3 +140,71 @@
     font-size: 10px;
   }
 }
+
+.home-e2e {
+  width: min(860px, 100%);
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.home-e2e-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.home-e2e-header h3 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.home-e2e-badge {
+  font-size: 11px;
+  border-radius: 999px;
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+}
+.home-e2e-badge.passed { color: var(--green); border-color: var(--green); background: var(--green-dim); }
+.home-e2e-badge.failed { color: var(--red); border-color: var(--red); background: var(--red-dim); }
+.home-e2e-badge.running { color: var(--yellow); border-color: var(--yellow); background: var(--yellow-dim); }
+
+.home-e2e-desc {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.home-e2e-checklist {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.home-e2e-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 8px 10px;
+  font-size: 12px;
+}
+
+.home-e2e-step .status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+.home-e2e-step.pass .status-dot { background: var(--green); }
+.home-e2e-step.fail .status-dot { background: var(--red); }
+.home-e2e-step.pending .status-dot { background: var(--yellow); }
+
+.home-e2e-step code { color: var(--text-1); }
+.home-e2e-step .status-text { margin-left: auto; font-weight: 600; }

--- a/web/src/tabs/HomeTab.jsx
+++ b/web/src/tabs/HomeTab.jsx
@@ -4,14 +4,125 @@
  * Shows quick status overview and getting-started hints.
  */
 
-import { useStore } from '../core/store';
+import { useEffect, useMemo, useState } from 'react';
+import { publishROS } from '../core/ros';
+import { LOG_TAGS, useStore } from '../core/store';
 import './HomeTab.css';
+
+const E2E_TIMEOUT_MS = 12000;
+const E2E_SEQUENCE = [
+  '/dori/stt/result',
+  '/dori/llm/query',
+  '/dori/llm/response',
+  '/dori/tts/speaking',
+  '/dori/tts/done',
+];
 
 export default function HomeTab() {
   const connected  = useStore(s => s.connected);
   const isDemoMode = useStore(s => s.isDemoMode);
   const hriState   = useStore(s => s.hriState);
   const log        = useStore(s => s.log);
+  const addLog     = useStore(s => s.addLog);
+  const topicStats = useStore(s => s.topicStats);
+
+  const [runState, setRunState] = useState({
+    phase: 'idle', // idle | running | passed | failed
+    startedAt: null,
+    baseline: {},
+    failedAt: null,
+  });
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (runState.phase !== 'running') return undefined;
+    const id = setInterval(() => setTick(t => t + 1), 250);
+    return () => clearInterval(id);
+  }, [runState.phase]);
+
+  const startedAt = runState.startedAt ?? 0;
+  const elapsedMs = runState.phase === 'running' ? Math.max(0, Date.now() - startedAt) : 0;
+
+  const stepStatuses = useMemo(() => {
+    void tick;
+    const result = [];
+    let prevAt = startedAt;
+    let firstFailed = null;
+
+    for (const topic of E2E_SEQUENCE) {
+      const lastSeenMs = topicStats?.[topic]?.lastSeenMs ?? 0;
+      const baselineMs = runState.baseline?.[topic] ?? 0;
+      const hitAt = lastSeenMs > baselineMs ? lastSeenMs : null;
+      const done = !!hitAt;
+      let status = 'pending';
+
+      if (done) status = 'pass';
+      else if (runState.phase === 'failed' && !firstFailed) {
+        status = 'fail';
+        firstFailed = topic;
+      } else if (runState.phase === 'running' && elapsedMs >= E2E_TIMEOUT_MS && !firstFailed) {
+        status = 'fail';
+        firstFailed = topic;
+      }
+
+      if (!done && status !== 'fail' && firstFailed) status = 'skipped';
+
+      result.push({ topic, status, hitAt, latencyMs: done ? hitAt - prevAt : null });
+      if (done) prevAt = hitAt;
+    }
+    return result;
+  }, [topicStats, runState, startedAt, elapsedMs, tick]);
+
+  useEffect(() => {
+    if (runState.phase !== 'running') return;
+
+    const allPassed = stepStatuses.every(s => s.status === 'pass');
+    if (allPassed) {
+      addLog(LOG_TAGS.TEST, '[e2e] conversation pipeline PASSED');
+      setRunState(s => ({ ...s, phase: 'passed' }));
+      return;
+    }
+
+    const hasFailed = stepStatuses.some(s => s.status === 'fail');
+    if (hasFailed || elapsedMs >= E2E_TIMEOUT_MS) {
+      const failedStep = stepStatuses.find(s => s.status === 'fail' || s.status === 'pending')?.topic;
+      addLog(LOG_TAGS.ERROR, `[e2e] conversation pipeline FAILED at ${failedStep || 'unknown step'}`);
+      setRunState(s => ({ ...s, phase: 'failed', failedAt: failedStep || null }));
+    }
+  }, [stepStatuses, elapsedMs, runState.phase, addLog]);
+
+  function startConversationE2E() {
+    const baseline = E2E_SEQUENCE.reduce((acc, topic) => {
+      acc[topic] = topicStats?.[topic]?.lastSeenMs ?? 0;
+      return acc;
+    }, {});
+    const now = Date.now();
+
+    setRunState({
+      phase: 'running',
+      startedAt: now,
+      baseline,
+      failedAt: null,
+    });
+
+    const payload = {
+      text: 'Conversation E2E test 시작',
+      confidence: 1.0,
+      source: 'dashboard_e2e_test',
+      timestamp: new Date(now).toISOString(),
+    };
+    publishROS('/dori/stt/result', 'std_msgs/msg/String', { data: JSON.stringify(payload) });
+    addLog(LOG_TAGS.TEST, '[e2e] conversation test triggered from dashboard');
+  }
+
+  const badgeClass = `home-e2e-badge ${runState.phase}`;
+  const badgeText = runState.phase === 'passed'
+    ? 'PIPELINE PASS'
+    : runState.phase === 'failed'
+      ? 'PIPELINE FAIL'
+      : runState.phase === 'running'
+        ? 'RUNNING'
+        : 'NOT RUN';
 
   return (
     <div className="home-root">
@@ -44,6 +155,32 @@ export default function HomeTab() {
       </div>
 
       {/* Hint */}
+      <div className="home-e2e">
+        <div className="home-e2e-header">
+          <h3>Conversation E2E Test</h3>
+          <span className={badgeClass}>{badgeText}</span>
+        </div>
+        <p className="home-e2e-desc">한 번 클릭으로 STT → HRI → LLM → TTS 파이프라인 상태 전이를 검사합니다.</p>
+        <button className="btn btn-primary" onClick={startConversationE2E} disabled={runState.phase === 'running'}>
+          {runState.phase === 'running' ? 'Running…' : 'Run Conversation E2E Test'}
+        </button>
+
+        <div className="home-e2e-checklist">
+          {stepStatuses.map(step => (
+            <div key={step.topic} className={`home-e2e-step ${step.status}`}>
+              <span className="status-dot" />
+              <code>{step.topic}</code>
+              <span className="status-text">{
+                step.status === 'pass' ? `PASS (${step.latencyMs}ms)`
+                  : step.status === 'fail' ? `FAIL ${runState.failedAt === step.topic ? '(timeout/missing)' : ''}`
+                    : step.status === 'skipped' ? 'SKIPPED'
+                      : 'PENDING'
+              }</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
       <div className="home-hint">
         <p>← 사이드바에서 탭을 선택하거나, 우측 상단에서 ROS에 연결하세요.</p>
         <p>ROS 없이 테스트하려면 <code>▶ demo</code> 버튼을 누르세요.</p>


### PR DESCRIPTION
### Motivation
- Provide a single-click way to exercise and verify the STT→LLM→TTS conversation pipeline from the dashboard.  
- Show per-stage pass/fail status and surface which stage timed out or was missing for faster debugging.  
- Reuse existing topic hit/stat collection (`topicStats`) to determine whether each expected topic was observed during the run.

### Description
- Added a new E2E test panel and control logic in `web/src/tabs/HomeTab.jsx` that snapshots a per-run baseline, triggers `/dori/stt/result` via `publishROS`, and tracks ordered topic hits for `['/dori/stt/result','/dori/llm/query','/dori/llm/response','/dori/tts/speaking','/dori/tts/done']`.  
- Implemented run state machine (`idle | running | passed | failed`) with a `12s` timeout and logic that compares `topicStats[topic].lastSeenMs` against the baseline to determine hit ordering and latency.  
- Added a checklist UI and single pipeline badge (`NOT RUN`, `RUNNING`, `PIPELINE PASS`, `PIPELINE FAIL`) plus failure localization to indicate which step failed or timed out.  
- Added corresponding styles to `web/src/tabs/HomeTab.css` for the E2E block, checklist rows, status dot, and badge.

### Testing
- Built the web client with `cd web && npm run build`, which completed successfully.  
- No additional automated tests were added; the change relies on existing `recordTopicHit`/`topicStats` data already populated by the store.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c726f438832c9c0147a3c815c650)