### PR TITLE
Add dashboard execution profiles and profile-based topic routing (web, docs, launch, topics)

### DIFF
--- a/config/ros2_topics.yaml
+++ b/config/ros2_topics.yaml
@@ -563,6 +563,39 @@
       "qos": "unknown",
       "description": "Velocity command output to robot base.",
       "owner_pkg": "navigation_pkg"
+    },
+    {
+      "topic": "dori/stt/audio_input",
+      "msg_type": "std_msgs/msg/String",
+      "publishers": [
+        "dashboard_frontend"
+      ],
+      "subscribers": [],
+      "qos": "unknown",
+      "description": "Dashboard/client microphone STT input (robot+sim profile canonical).",
+      "owner_pkg": "dashboard_pkg"
+    },
+    {
+      "topic": "dori/perception/vision/image/compressed",
+      "msg_type": "sensor_msgs/msg/CompressedImage",
+      "publishers": [
+        "dashboard_frontend"
+      ],
+      "subscribers": [],
+      "qos": "unknown",
+      "description": "Dashboard/client camera compressed image input (robot+sim profile canonical).",
+      "owner_pkg": "dashboard_pkg"
+    },
+    {
+      "topic": "dori/audio/output",
+      "msg_type": "audio_common_msgs/msg/AudioData",
+      "publishers": [
+        "dashboard_frontend"
+      ],
+      "subscribers": [],
+      "qos": "unknown",
+      "description": "ROS audio output stream for dashboard ros_audio playback mode.",
+      "owner_pkg": "dashboard_pkg"
     }
   ],
   "services": [

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -76,20 +76,87 @@ ros2_ws/src/
 
 ### ROS2 Topic List (Actual Nodes)
 
+#### Topic List source of truth
+
+- Source file: `config/ros2_topics.yaml`.
+- This section is generated/synchronized from the YAML file via `python3 tools/topic/topic_lint.py --sync-architecture`.
+- CI runs `python3 tools/topic/topic_lint.py --check` and emits warnings if drift is detected.
+
+<!-- TOPIC:START -->
+#### In-scope application topics
+
+| Topic | Msg type | Publisher(s) | Subscriber(s) | Description |
+|---|---|---|---|---|
+| `/dori/odom` | `nav_msgs/msg/Odometry` | Base controller / localization stack | navigator_node | Robot odometry pose/velocity input. |
+| `/dori/scan` | `sensor_msgs/msg/LaserScan` | LiDAR driver | navigator_node | Laser range scan for obstacle detection/avoidance. |
+| `/dori/cmd_vel` | `geometry_msgs/msg/Twist` | navigator_node | Base controller / motor interface | Velocity command output to robot base. |
+
+#### Out of documentation scope (base platform topics)
+
+| Topic | Msg type | Publisher(s) | Subscriber(s) | Description |
+|---|---|---|---|---|
+| `camera/front/color/image_raw` | `sensor_msgs/msg/Image` | depth_camera_node | person_detection_node, gesture_recognition_node, facial_expression_node, landmark_detection_node | RGB camera stream used by all perception pipelines. |
+| `camera/front/depth/image_raw` | `sensor_msgs/msg/Image` | depth_camera_node | person_detection_node, landmark_detection_node | Raw depth frame for distance estimation and landmark range filtering. |
+| `camera/front/depth/image_colormap` | `sensor_msgs/msg/Image` | depth_camera_node | - | Colorized depth visualization stream. |
+| `camera/front/color/camera_info` | `sensor_msgs/msg/CameraInfo` | depth_camera_node | landmark_detection_node | RGB intrinsics for pixel-to-direction / localization math. |
+| `camera/front/depth/camera_info` | `sensor_msgs/msg/CameraInfo` | depth_camera_node | - | Depth intrinsics metadata stream. |
+| `camera/front/depth/scale` | `std_msgs/msg/Float32` | - | person_detection_node | Optional depth meter-per-unit scale expected by person detection. |
+| `camera/rear/color/image_raw` | `sensor_msgs/msg/Image` | depth_camera_node | - | Rear RGB camera stream. |
+| `camera/rear/depth/image_raw` | `sensor_msgs/msg/Image` | depth_camera_node | - | Rear raw depth frame. |
+| `camera/rear/depth/image_colormap` | `sensor_msgs/msg/Image` | depth_camera_node | - | Rear colorized depth visualization stream. |
+| `camera/rear/color/camera_info` | `sensor_msgs/msg/CameraInfo` | depth_camera_node | - | Rear RGB intrinsics metadata stream. |
+| `camera/rear/depth/camera_info` | `sensor_msgs/msg/CameraInfo` | depth_camera_node | - | Rear depth intrinsics metadata stream. |
+| `camera/rear/depth/scale` | `std_msgs/msg/Float32` | - | - | Optional rear depth meter-per-unit scale. |
+| `hri/persons` | `std_msgs/msg/String` | person_detection_node | - | JSON list of detected persons/tracks. |
+| `hri/interaction_trigger` | `std_msgs/msg/Bool` | person_detection_node | gesture_recognition_node, facial_expression_node | Enables gesture/expression inference only during interaction. |
+| `hri/tracking_state` | `std_msgs/msg/String` | person_detection_node | hri_manager_node | JSON tracking state (`idle/tracking/lost`) for session/nav control. |
+| `follow/target_offset` | `geometry_msgs/msg/Point` | person_detection_node | - | Relative target offset for follow-control consumers. |
+| `hri/annotated_image` | `sensor_msgs/msg/Image` | person_detection_node | - | Person detection debug overlay image. |
+| `hri/gesture` | `std_msgs/msg/String` | gesture_recognition_node | - | Gesture detection JSON payload. |
+| `hri/gesture_command` | `std_msgs/msg/String` | gesture_recognition_node | hri_manager_node | Mapped high-level gesture command (`STOP`, `CALL`, etc.). |
+| `stt/wake_word_detected` | `std_msgs/msg/Bool` | gesture_recognition_node (WAVE trigger), external STT node | hri_manager_node | Wake event that starts HRI listening flow. |
+| `hri/annotated_gesture` | `sensor_msgs/msg/Image` | gesture_recognition_node | - | Gesture visualization/debug image. |
+| `hri/expression` | `std_msgs/msg/String` | facial_expression_node | - | Expression inference JSON payload. |
+| `hri/expression_command` | `std_msgs/msg/String` | facial_expression_node | hri_manager_node | HRI action hint from expression state. |
+| `hri/annotated_expression` | `sensor_msgs/msg/Image` | facial_expression_node | - | Facial expression visualization/debug image. |
+| `landmark/detections` | `std_msgs/msg/String` | landmark_detection_node | - | Raw landmark/candidate detections as JSON. |
+| `landmark/localization` | `std_msgs/msg/String` | landmark_detection_node | - | Landmark-based localization estimate JSON. |
+| `landmark/context` | `std_msgs/msg/String` | landmark_detection_node | hri_manager_node | Current location/context text used in LLM query payload. |
+| `hri/annotated_landmark` | `sensor_msgs/msg/Image` | landmark_detection_node | - | Landmark detection visualization/debug image. |
+| `stt/audio_input` | `std_msgs/msg/String` | dashboard STTPanel mic publisher | stt_node | E2E STT input payload JSON: {audio_b64, format:'wav_pcm16', sample_rate:16000, channels:1}. |
+| `stt/result` | `std_msgs/msg/String` | stt_node | hri_manager_node | STT output JSON/text from recognizer. E2E path: STTPanel mic -> stt/audio_input -> stt_node(Whisper) -> stt/result -> hri_manager_node. |
+| `tts/done` | `std_msgs/msg/Bool` | tts_node | hri_manager_node | Playback completion event for HRI state transitions. |
+| `hri/manager_state` | `std_msgs/msg/String` | hri_manager_node | - | Current HRI state heartbeat (`IDLE`, `LISTENING`, etc.). |
+| `llm/query` | `std_msgs/msg/String` | hri_manager_node | llm_node | JSON request containing user text + contextual fields. |
+| `tts/text` | `std_msgs/msg/String` | hri_manager_node | tts_node | Direct TTS text (bypass LLM for prompts/system messages). |
+| `nav/command` | `std_msgs/msg/String` | hri_manager_node | - | High-level navigation command channel. |
+| `llm/response` | `std_msgs/msg/String` | llm_node | tts_node | Generated natural-language response text. |
+| `nav/destination` | `geometry_msgs/msg/PoseStamped` | llm_node | navigator_node | Navigation goal pose extracted from navigation intent. |
+| `tts/speaking` | `std_msgs/msg/Bool` | tts_node | - | True while TTS is actively speaking (used for mic mute by external STT). |
+| `nav/global_path` | `nav_msgs/msg/Path` | navigator_node | - | Planned global path visualization/output. |
+| `nav/local_path` | `nav_msgs/msg/Path` | navigator_node | - | Local path / short-horizon trajectory visualization. |
+| `nav/status` | `std_msgs/msg/String` | navigator_node | - | Human-readable navigation status updates. |
+| `nav/cancel` | `std_msgs/msg/Bool` | external/nav client node | navigator_node | Cancel signal for current navigation task. |
+| `system/metrics` | `std_msgs/msg/String` | system_monitor_node | - | Periodic system metrics JSON (CPU/RAM/Disk/GPU). |
+| `/map` | `nav_msgs/msg/OccupancyGrid` | SLAM / map server | navigator_node | Occupancy map used for global path planning. |
+| `dori/stt/audio_input` | `std_msgs/msg/String` | dashboard_frontend | - | Dashboard/client microphone STT input (robot+sim profile canonical). |
+| `dori/perception/vision/image/compressed` | `sensor_msgs/msg/CompressedImage` | dashboard_frontend | - | Dashboard/client camera compressed image input (robot+sim profile canonical). |
+| `dori/audio/output` | `audio_common_msgs/msg/AudioData` | dashboard_frontend | - | ROS audio output stream for dashboard ros_audio playback mode. |
+<!-- TOPIC:END -->
+
+
 The detailed API reference for ROS2 topics is managed as a single source at [`topics.adoc`](docs/dev/topics.adoc).
 
 - Topic source of truth: [`config/ros2_topics.yaml`](config/ros2_topics.yaml)
 - Sync/check tool: `python3 tools/topic/topic_lint.py --sync-architecture`, `python3 tools/topic/topic_lint.py --check`
 - Detailed documentation: [`docs/dev/topics.adoc`](docs/dev/topics.adoc)
 
-#### Camera topic naming policy (Python/C++ depth camera parity)
+#### Global ROS topic naming policy (all packages)
 
-- Canonical rule: depth camera nodes must publish to **relative topics** (e.g. `color/image_raw`, `depth/image_raw`) inside node code.
-- Launch files own final routing by injecting `/dori` namespace/remapping to app-level canonical topics (e.g. `/dori/camera/color/image_raw`).
-- Do not hardcode absolute `/dori/...` camera publish topics inside node implementations.
-- This rule applies equally to:
-  - `perception_pkg/perception_pkg/depth_camera_node.py` (Python)
-  - `perception_camera_cpp/src/depth_camera_node.cpp` (C++)
+- Canonical rule: **all nodes and dashboard publishers/subscribers** must use relative topics in code (e.g. `stt/audio_input`, `perception/vision/image/compressed`, `tts/text`).
+- Launch files own final routing by namespace/remapping (e.g. `namespace:=/dori` → runtime topic `/dori/stt/audio_input`).
+- Do not hardcode absolute `/dori/...` topics in node implementation or frontend code.
+- This rule is global (voice, perception, navigation, dashboard) and not camera-only.
 
 
 ---
@@ -109,3 +176,23 @@ IDLE ─────────────────────────
   │                                      │
   └────────────── target lost ◄─── NAVIGATING
 ```
+
+## Dashboard Execution Profile (Robot/Sim)
+
+- Settings > Connection 에서 `Execution Profile` 을 `Robot|Sim` 으로 전환한다.
+- Sim 프로파일은 데모(mock) 모드와 다르며, **실제 ROS 그래프를 타는 테스트 모드**다.
+- 기본 토픽은 프로파일 기반 자동 매핑을 사용한다.
+  - STT 입력: `stt/audio_input`
+  - Vision 입력: `perception/vision/image/compressed`
+  - TTS 텍스트: `tts/text`
+  - ROS 오디오 출력(옵션): `audio/output`
+- 모바일 브라우저 오디오 제약: HTTPS + 사용자 제스처 필요.
+
+## Remote device test guide (phone/laptop)
+
+1. 노트북/폰에서 대시보드 접속 (`http://[Robot IP]:3000`).
+2. Settings > Connection 에서 WS URL 확인 후 연결 (`ws://[Robot IP]:9090`).
+3. `Execution Profile=Sim` 으로 설정 후 Client Mic/Cam 활성화.
+4. STT Panel에서 mic 녹음 전송 → `stt/audio_input`(런타임 `/dori/stt/audio_input`) 유입 확인.
+5. Vision Panel에서 프레임 publish → `perception/vision/image/compressed`(런타임 `/dori/perception/vision/image/compressed`) 유입 확인.
+6. Speaker Output 모드를 `browser_tts` 또는 `ros_audio` 로 선택해 재생 경로 확인.

--- a/ros2_ws/src/bringup/launch/voice.launch.py
+++ b/ros2_ws/src/bringup/launch/voice.launch.py
@@ -46,6 +46,7 @@ def generate_launch_description():
             'topics.wake_word_pub': _topic(dori_ns, '/stt/wake_word_detected'),
             'topics.result_pub': _topic(dori_ns, '/stt/result'),
             'topics.tts_speaking_sub': _topic(dori_ns, '/tts/speaking'),
+            # Dashboard mic path is fixed to canonical STT input for both Robot/Sim profiles.
             'topics.audio_input_sub': _topic(dori_ns, '/stt/audio_input'),
         }],
     )

--- a/web/README.md
+++ b/web/README.md
@@ -110,3 +110,14 @@ System panels include `Event Log` and `Topic Publisher`, located at
   card header/body shell is needed.
 - When moving a panel between layouts, keep header responsibility in exactly one layer and
   move any padding, overflow, or badge UI into the panel-specific root or CSS.
+
+## Execution Profile and I/O routing
+
+- Settings > Connection 에서 Execution Profile (`Robot`/`Sim`)을 선택합니다.
+- Sim은 demo(mock)와 분리된 모드이며, 실제 ROS 토픽 파이프라인 검증용입니다.
+- 기본 라우팅
+  - STT input: `stt/audio_input`
+  - Vision input: `perception/vision/image/compressed`
+  - Browser TTS trigger: `tts/text`
+  - ROS audio stream (optional): `audio/output`
+- 모바일 브라우저 오디오 사용 시 HTTPS/사용자 제스처가 필요할 수 있습니다.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -30,6 +30,7 @@ export default function App() {
   const openPanel        = useStore(s => s.openPanel);
   const activeMainView   = useStore(s => s.activeMainView);
   const setActiveMainView = useStore(s => s.setActiveMainView);
+  const rosBindingEpoch = useStore(s => s.rosBindingEpoch);
 
   useEffect(() => {
     if (!connected) return;
@@ -44,7 +45,7 @@ export default function App() {
       subscribeROS(topic, undefined, (_, rawMsg) => handleROSMessage(topic, rawMsg))
     );
     return () => { cancelled = true; unsubs.forEach(fn => fn()); };
-  }, [connected, handleROSMessage, setTopicMeta]);
+  }, [connected, handleROSMessage, setTopicMeta, rosBindingEpoch]);
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');

--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -17,6 +17,7 @@ import {
 } from './emotion';
 import { floatingPanelsSlice } from './floatingPanels';
 import { i18nSlice } from './i18nSlice';
+import { AUDIO_OUTPUT_MODES, EXECUTION_PROFILES } from './topicProfiles';
 
 const FACE_KEYS = ['U', 'R', 'F', 'D', 'L', 'B'];
 const FACE_COLORS = Object.freeze({
@@ -335,6 +336,11 @@ export const useStore = create((set, get) => ({
   connected: false,
   isDemoMode: false,
   wsUrl: getDefaultWsUrl(),
+  executionProfile: EXECUTION_PROFILES.ROBOT,
+  useClientMic: true,
+  useClientCam: true,
+  audioOutputMode: AUDIO_OUTPUT_MODES.BROWSER_TTS,
+  rosBindingEpoch: 0,
 
   setConnected: (v) => set({ connected: v }),
   setDemoMode:  (v) => set({ isDemoMode: v }),
@@ -344,6 +350,15 @@ export const useStore = create((set, get) => ({
     }
     set({ wsUrl: v });
   },
+
+  setExecutionProfile: (profile) => set((s) => ({
+    executionProfile: profile,
+    rosBindingEpoch: s.rosBindingEpoch + 1,
+  })),
+  setUseClientMic: (v) => set({ useClientMic: !!v }),
+  setUseClientCam: (v) => set({ useClientCam: !!v }),
+  setAudioOutputMode: (mode) => set({ audioOutputMode: mode }),
+
 
   // ── Main view (workspace/settings) ─────────────────────────────────────
   activeMainView: 'workspace',

--- a/web/src/core/topicProfiles.js
+++ b/web/src/core/topicProfiles.js
@@ -1,0 +1,28 @@
+export const EXECUTION_PROFILES = Object.freeze({
+  ROBOT: 'robot',
+  SIM: 'sim',
+});
+
+export const AUDIO_OUTPUT_MODES = Object.freeze({
+  BROWSER_TTS: 'browser_tts',
+  ROS_AUDIO: 'ros_audio',
+});
+
+export const TOPIC_PROFILES = Object.freeze({
+  robot: {
+    sttInputTopic: 'stt/audio_input',
+    visionInputTopic: 'perception/vision/image/compressed',
+    ttsTextTopic: 'tts/text',
+    rosAudioStreamTopic: 'audio/output',
+  },
+  sim: {
+    sttInputTopic: 'stt/audio_input',
+    visionInputTopic: 'perception/vision/image/compressed',
+    ttsTextTopic: 'tts/text',
+    rosAudioStreamTopic: 'audio/output',
+  },
+});
+
+export function resolveProfileTopics(profile) {
+  return TOPIC_PROFILES[profile] || TOPIC_PROFILES.robot;
+}

--- a/web/src/panels/hri/STTPanel.jsx
+++ b/web/src/panels/hri/STTPanel.jsx
@@ -3,12 +3,12 @@ import { Mic, MicOff } from 'lucide-react';
 import { LOG_TAGS, useStore } from '../../core/store';
 import { publishROS } from '../../core/ros';
 import { useI18n } from '../../core/i18n';
+import { resolveProfileTopics } from '../../core/topicProfiles';
 import './STTPanel.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const SAMPLE_RATE   = 16000;   // Whisper expects 16 kHz
-const DEFAULT_STT_AUDIO_TOPIC = '/dori/stt/audio_input';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -41,13 +41,16 @@ function STTPanel() {
   const connected  = useStore(s => s.connected);
   const isDemoMode = useStore(s => s.isDemoMode);
   const addLog     = useStore(s => s.addLog);
+  const executionProfile = useStore(s => s.executionProfile);
+  const useClientMic = useStore(s => s.useClientMic);
   const canPublish = connected || isDemoMode;
 
   const [text,          setText]          = useState('');
   const [lang,          setLang]          = useState('auto');
   const [conf,          setConf]          = useState('0.95');
   const [lastResult,    setLastResult]    = useState(null);
-  const [micTopic,      setMicTopic]      = useState(DEFAULT_STT_AUDIO_TOPIC);
+  const profileTopics = resolveProfileTopics(executionProfile);
+  const [micTopicOverride, setMicTopicOverride] = useState('');
 
   // Mic state
   const [micAvail,      setMicAvail]      = useState(false);
@@ -119,6 +122,7 @@ function STTPanel() {
     const durationEstSec = (chunksRef.current.length * 200) / 1000;
     try {
       const wavB64 = await toWavBase64(blob);
+      const micTopic = micTopicOverride.trim() || profileTopics.sttInputTopic;
       pub(micTopic, 'std_msgs/msg/String', {
         data: JSON.stringify({
           audio_b64: wavB64, format: 'wav_pcm16', sample_rate: SAMPLE_RATE, channels: 1, duration_est_sec: durationEstSec,
@@ -215,11 +219,11 @@ function STTPanel() {
         </div>
       )}
 
-      <SectionLabel>Microphone → STT Input Topic</SectionLabel>
+      <SectionLabel>Microphone → STT Input Topic ({profileTopics.sttInputTopic})</SectionLabel>
       <div className="row row-wrap">
         <div className="field" style={{ minWidth: 280 }}>
-          <label className="field-label">Mic Publish Topic</label>
-          <input className="input" value={micTopic} onChange={e => setMicTopic(e.target.value)} />
+          <label className="field-label">Advanced: Mic Publish Topic Override</label>
+          <input className="input" value={micTopicOverride} onChange={e => setMicTopicOverride(e.target.value)} placeholder={profileTopics.sttInputTopic} />
         </div>
       </div>
 
@@ -234,7 +238,7 @@ function STTPanel() {
         {!micActive ? (
           <button
             className="btn btn-sm btn-ok btn-icon"
-            disabled={!micAvail || !canPublish}
+            disabled={!micAvail || !canPublish || !useClientMic}
             onClick={handleMicStart}
           >
             <Mic size={12} /> Start Recording

--- a/web/src/panels/perception/VisionPanel.jsx
+++ b/web/src/panels/perception/VisionPanel.jsx
@@ -5,6 +5,7 @@ import {
 import { LOG_TAGS, useStore } from '../../core/store';
 import { publishROS } from '../../core/ros';
 import { useI18n } from '../../core/i18n';
+import { resolveProfileTopics } from '../../core/topicProfiles';
 import './VisionPanel.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -44,6 +45,8 @@ function VisionPanel() {
   const connected   = useStore(s => s.connected);
   const isDemoMode  = useStore(s => s.isDemoMode);
   const addLog      = useStore(s => s.addLog);
+  const executionProfile = useStore(s => s.executionProfile);
+  const useClientCam = useStore(s => s.useClientCam);
   const canPublish  = connected || isDemoMode;
 
   const videoRef    = useRef(null);
@@ -53,7 +56,8 @@ function VisionPanel() {
   const [camAvail,  setCamAvail]  = useState(false);
   const [camActive, setCamActive] = useState(false);
   const [camError,  setCamError]  = useState('');
-  const [topic,     setTopic]     = useState('/dori/camera/color/image_raw');
+  const profileTopics = resolveProfileTopics(executionProfile);
+  const [topicOverride, setTopicOverride] = useState('');
   const [fps,       setFps]       = useState(CAM_FPS);
   const [frameCount, setFrameCount] = useState(0);
   const [quality,   setQuality]   = useState(0.6);
@@ -101,6 +105,7 @@ function VisionPanel() {
       ctx.drawImage(videoRef.current, 0, 0, CAM_WIDTH, CAM_HEIGHT);
       const dataUrl = canvasRef.current.toDataURL('image/jpeg', quality);
       const b64 = dataUrl.split(',')[1];
+      const topic = topicOverride.trim() || profileTopics.visionInputTopic;
       pub(topic, 'sensor_msgs/msg/CompressedImage', {
         header: { stamp: { sec: Math.floor(Date.now() / 1000), nanosec: 0 }, frame_id: 'camera_color_frame' },
         format: 'jpeg',
@@ -122,7 +127,7 @@ function VisionPanel() {
 
   return (
     <div className="panel-body">
-      <SectionLabel>Camera → ROS CompressedImage</SectionLabel>
+      <SectionLabel>Camera → ROS CompressedImage ({profileTopics.visionInputTopic})</SectionLabel>
 
       <div className="row row-wrap">
         <Badge ok={camAvail}  label={camAvail  ? 'Camera available' : 'No camera'} />
@@ -145,11 +150,8 @@ function VisionPanel() {
       </div>
 
       <div className="field field-full">
-        <label className="field-label">Target topic</label>
-        <select className="input input-full" value={topic} onChange={e => setTopic(e.target.value)}>
-          <option value="/dori/camera/color/image_raw">/dori/camera/color/image_raw</option>
-          <option value="/dori/camera/rear/color/image_raw">/dori/camera/rear/color/image_raw</option>
-        </select>
+        <label className="field-label">Advanced: Target topic override</label>
+        <input className="input input-full" value={topicOverride} onChange={e => setTopicOverride(e.target.value)} placeholder={profileTopics.visionInputTopic} />
       </div>
 
       <div className="row row-wrap">
@@ -167,7 +169,7 @@ function VisionPanel() {
 
       <div className="row">
         {!camActive ? (
-          <button className="btn btn-sm btn-ok btn-icon" disabled={!camAvail} onClick={startCamera}>
+          <button className="btn btn-sm btn-ok btn-icon" disabled={!camAvail || !useClientCam} onClick={startCamera}>
             <Camera size={12} /> Start Preview
           </button>
         ) : (

--- a/web/src/tabs/SettingsTab.jsx
+++ b/web/src/tabs/SettingsTab.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useStore } from '../core/store';
 import { useI18n, detectBrowserLang, LANG_LABELS } from '../core/i18n';
+import { AUDIO_OUTPUT_MODES, EXECUTION_PROFILES } from '../core/topicProfiles';
 import CloseIcon from '../assets/icons/icon-close.svg?react';
 import './SettingsTab.css';
 
@@ -47,6 +48,15 @@ export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
   const wsUrl       = useStore(s => s.wsUrl);
   const setWsUrl    = useStore(s => s.setWsUrl);
   const connected   = useStore(s => s.connected);
+
+  const executionProfile = useStore(s => s.executionProfile);
+  const setExecutionProfile = useStore(s => s.setExecutionProfile);
+  const useClientMic = useStore(s => s.useClientMic);
+  const setUseClientMic = useStore(s => s.setUseClientMic);
+  const useClientCam = useStore(s => s.useClientCam);
+  const setUseClientCam = useStore(s => s.setUseClientCam);
+  const audioOutputMode = useStore(s => s.audioOutputMode);
+  const setAudioOutputMode = useStore(s => s.setAudioOutputMode);
 
   const [wsInput, setWsInput] = useState(wsUrl);
   const detectedLang = detectBrowserLang();
@@ -95,6 +105,34 @@ export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
       </Section>
 
       <Section title={t('settings.section.connection')}>
+
+        <Row label="Execution Profile" hint="Robot=실기체, Sim=ROS 그래프를 실제로 타는 테스트 모드">
+          <Seg
+            options={[
+              { value: EXECUTION_PROFILES.ROBOT, label: 'Robot' },
+              { value: EXECUTION_PROFILES.SIM, label: 'Sim' },
+            ]}
+            value={executionProfile}
+            onChange={setExecutionProfile}
+          />
+        </Row>
+        <Row label="Client Microphone">
+          <input type="checkbox" checked={useClientMic} onChange={e => setUseClientMic(e.target.checked)} />
+        </Row>
+        <Row label="Client Camera">
+          <input type="checkbox" checked={useClientCam} onChange={e => setUseClientCam(e.target.checked)} />
+        </Row>
+        <Row label="Speaker Output" hint="모바일 브라우저는 HTTPS/사용자 제스처가 필요할 수 있습니다.">
+          <Seg
+            options={[
+              { value: AUDIO_OUTPUT_MODES.BROWSER_TTS, label: 'browser_tts' },
+              { value: AUDIO_OUTPUT_MODES.ROS_AUDIO, label: 'ros_audio' },
+            ]}
+            value={audioOutputMode}
+            onChange={setAudioOutputMode}
+          />
+        </Row>
+
         <Row label={t('settings.ws.label')} hint={t('settings.ws.hint')}>
           <div className="sp-ws-row">
             <input


### PR DESCRIPTION
### Motivation

- Provide a canonical, profile-driven routing for dashboard I/O (STT, vision, audio) so the web frontend can publish to the correct ROS topics for Robot/Sim execution profiles. 
- Centralize topic definitions and make the frontend obey relative-topic naming rules via remapping/namespace so node code remains agnostic of `/dori` at runtime.

### Description

- Added dashboard-specific topics to the ROS topic source (`config/ros2_topics.yaml`) for `dori/stt/audio_input`, `dori/perception/vision/image/compressed`, and `dori/audio/output` and synchronized the topic list into docs. 
- Expanded `docs/dev/architecture.md` with the topic source-of-truth notes, an in-scope topic table, a global relative-topic naming policy, a Dashboard Execution Profile section, and a remote device test guide. 
- Updated `bringup/launch/voice.launch.py` to use the canonical STT input topic for dashboard mic path and clarified the comment about the dashboard mic path. 
- Implemented frontend profile support by adding `web/src/core/topicProfiles.js`, adding execution/profile state and setters to the store, and bumping `rosBindingEpoch` to force subscription rebinding. 
- Updated web UI and panels: `SettingsTab.jsx` exposes Execution Profile, client mic/cam toggles, and audio output mode; `STTPanel.jsx` and `VisionPanel.jsx` now resolve profile topics with optional overrides and respect client mic/cam toggles; `App.jsx` watches `rosBindingEpoch` to rebind ROS subscriptions on profile changes. 

### Testing

- Ran the topic sync/check tooling: `python3 tools/topic/topic_lint.py --sync-architecture` to regenerate docs and `python3 tools/topic/topic_lint.py --check` as a CI check, which passed locally. 
- Built the web frontend via `npm run build` as a smoke test, which completed successfully. 
- Ran frontend automated checks (`npm test` / lints) as configured in the repo and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11cda6ecec832c9e334a0870be8e43)