### PR TITLE
Add STT confidence policy and HRI reprompt + system-prompt cooldown

### DIFF
--- a/ros2_ws/src/interaction_pkg/interaction_pkg/hri_manager_node.py
+++ b/ros2_ws/src/interaction_pkg/interaction_pkg/hri_manager_node.py
@@ -47,6 +47,19 @@ class HRIState(str, Enum):
     NAVIGATING = 'NAVIGATING'
 
 
+
+SYSTEM_PROMPTS = {
+    'timeout_exit': '응답이 없어 대화를 종료할게요.',
+    'reprompt_short': '잘 못 들었어요. 다시 말씀해 주세요.',
+    'tts_error_retry': '죄송해요, 음성 출력에 문제가 있었어요. 다시 한 번 말씀해 주세요.',
+    'target_lost': '안내 대상을 잃어버렸습니다. 다시 불러주세요.',
+}
+
+STT_EVENTS = {
+    'RESULT': 'stt_result',
+    'EMPTY_OR_LOW_CONF': 'stt_empty_or_low_conf',
+}
+
 class HRIManagerNode(Node):
     def __init__(self):
         super().__init__('hri_manager_node')
@@ -55,6 +68,8 @@ class HRIManagerNode(Node):
         self.declare_parameter('greeting_text', '안녕하세요! 저는 캠퍼스 안내 로봇 도리입니다. 어디로 안내해드릴까요?')
         self.declare_parameter('idle_timeout_sec', 10.0)
         self.declare_parameter('wake_debounce_sec', 1.5)
+        self.declare_parameter('reprompt_max_count', 2)
+        self.declare_parameter('system_prompt_cooldown_sec', 2.0)
         self.declare_parameter('topics.wake_word_sub', 'stt/wake_word_detected')
         self.declare_parameter('topics.stt_result_sub', 'stt/result')
         self.declare_parameter('topics.tracking_state_sub', 'hri/tracking_state')
@@ -73,6 +88,8 @@ class HRIManagerNode(Node):
         self.greeting_text = self.get_parameter('greeting_text').value
         self.idle_timeout  = self.get_parameter('idle_timeout_sec').value
         self.wake_debounce_sec = self.get_parameter('wake_debounce_sec').value
+        self.reprompt_max_count = int(self.get_parameter('reprompt_max_count').value)
+        self.system_prompt_cooldown_sec = float(self.get_parameter('system_prompt_cooldown_sec').value)
 
         # State variables
         self.state: HRIState        = HRIState.IDLE
@@ -82,6 +99,8 @@ class HRIManagerNode(Node):
         self.last_wake_time: float  = 0.0
         self.activated: bool = False
         self.tts_retry_count: int = 0
+        self.reprompt_count: int = 0
+        self.last_system_prompt_time: dict[str, float] = {}
 
         wake_word_topic = self.get_parameter('topics.wake_word_sub').value
         stt_result_topic = self.get_parameter('topics.stt_result_sub').value
@@ -152,6 +171,7 @@ class HRIManagerNode(Node):
         if self.state == HRIState.IDLE:
             self.get_logger().info('Wake word detected — starting HRI session')
             self.activated = True
+            self.reprompt_count = 0
             self._transition(HRIState.LISTENING, reason='wake_word_detected')
             self._emit_wake_ack()
         else:
@@ -160,21 +180,29 @@ class HRIManagerNode(Node):
             )
 
     def _on_stt_result(self, msg: String):
-        """STT transcription received — forward to LLM with location context."""
+        """STT transcription/event received — forward valid text to LLM."""
         if self.state != HRIState.LISTENING:
             self.get_logger().debug('STT result ignored — not in LISTENING state')
             return
 
         try:
             data = json.loads(msg.data)
-            user_text = data.get('text', '').strip()
-        except (json.JSONDecodeError, AttributeError):
+            user_text = str(data.get('text', '')).strip()
+            event = str(data.get('event', STT_EVENTS['RESULT']))
+            confidence = float(data.get('confidence', 0.0))
+        except (json.JSONDecodeError, AttributeError, TypeError, ValueError):
             user_text = msg.data.strip()
+            event = STT_EVENTS['RESULT'] if user_text else STT_EVENTS['EMPTY_OR_LOW_CONF']
+            confidence = 0.0
 
-        if not user_text:
+        if event == STT_EVENTS['EMPTY_OR_LOW_CONF'] or not user_text:
+            self.get_logger().info(
+                f'STT empty/low-confidence event received (conf={confidence:.2f})'
+            )
+            self._handle_reprompt_or_end()
             return
 
-        self.get_logger().info(f'STT result: "{user_text}"')
+        self.get_logger().info(f'STT result: "{user_text}" (conf={confidence:.2f})')
         self._transition(HRIState.RESPONDING, reason='stt_result_received')
         self.tts_retry_count = 0
         self._send_to_llm(user_text)
@@ -191,7 +219,7 @@ class HRIManagerNode(Node):
             self.get_logger().info('Target lost — ending navigation')
             self._transition(HRIState.IDLE, reason='navigation_target_lost')
             self._set_follow_mode(False)
-            self._say('안내 대상을 잃어버렸습니다. 다시 불러주세요.')
+            self._say_system('target_lost')
 
     def _on_gesture_command(self, msg: String):
         try:
@@ -270,7 +298,7 @@ class HRIManagerNode(Node):
         if self.state == HRIState.RESPONDING:
             if self.tts_retry_count < 1:
                 self.tts_retry_count += 1
-                self._say('죄송해요, 음성 출력에 문제가 있었어요. 다시 한 번 말씀해 주세요.')
+                self._say_system('tts_error_retry')
             self._transition(HRIState.LISTENING, reason='tts_failure_recover')
 
     # State machine
@@ -290,6 +318,7 @@ class HRIManagerNode(Node):
                 self.get_logger().info(
                     f'LISTENING timeout ({self.idle_timeout}s) → IDLE'
                 )
+                self._say_system('timeout_exit')
                 self._transition(HRIState.IDLE, reason='listening_timeout')
                 self._set_follow_mode(False)
 
@@ -300,6 +329,38 @@ class HRIManagerNode(Node):
         msg.data = text
         self.tts_pub.publish(msg)
         self.get_logger().info(f'TTS: "{text}"')
+
+    def _say_system(self, prompt_key: str) -> bool:
+        text = SYSTEM_PROMPTS.get(prompt_key)
+        if not text:
+            self.get_logger().warn(f'Unknown system prompt key: {prompt_key}')
+            return False
+
+        now = time.time()
+        last_ts = self.last_system_prompt_time.get(prompt_key, 0.0)
+        if (now - last_ts) < self.system_prompt_cooldown_sec:
+            self.get_logger().info(
+                f'System prompt suppressed by cooldown: {prompt_key} ({now - last_ts:.2f}s)'
+            )
+            return False
+
+        self.last_system_prompt_time[prompt_key] = now
+        self._say(text)
+        return True
+
+    def _handle_reprompt_or_end(self):
+        if self.reprompt_count < self.reprompt_max_count:
+            self.reprompt_count += 1
+            self._say_system('reprompt_short')
+            self.get_logger().info(
+                f'Reprompt issued ({self.reprompt_count}/{self.reprompt_max_count})'
+            )
+            return
+
+        self.get_logger().info('Reprompt limit reached — ending session')
+        self._say_system('timeout_exit')
+        self._transition(HRIState.IDLE, reason='reprompt_limit_reached')
+        self._set_follow_mode(False)
 
     def _emit_wake_ack(self):
         """Emit wake acknowledgement after activation."""

--- a/ros2_ws/src/stt_pkg/stt_pkg/stt_node.py
+++ b/ros2_ws/src/stt_pkg/stt_pkg/stt_node.py
@@ -109,6 +109,7 @@ class STTNode(Node):
         self.declare_parameter('silence_duration', 1.2)
         self.declare_parameter('topics.wake_word_pub', 'stt/wake_word_detected')
         self.declare_parameter('topics.result_pub', 'stt/result')
+        self.declare_parameter('min_confidence', 0.55)
         self.declare_parameter('topics.tts_speaking_sub', 'tts/speaking')
         self.declare_parameter('topics.audio_input_sub', 'stt/audio_input')
         self.declare_parameter('audio_input_mode', 'microphone')
@@ -120,6 +121,7 @@ class STTNode(Node):
         device           = self.get_parameter('whisper_device').value
         self.vad_threshold   = self.get_parameter('vad_threshold').value
         self.vad_silence_sec = self.get_parameter('silence_duration').value
+        self.min_confidence = float(self.get_parameter('min_confidence').value)
 
         wake_word_topic = self.get_parameter('topics.wake_word_pub').value
         result_topic = self.get_parameter('topics.result_pub').value
@@ -429,21 +431,32 @@ class STTNode(Node):
                 min(1.0, max(0.0, np.exp(np.mean(logprobs))))
             ) if logprobs else 0.5
 
-            if text:
-                payload = {
-                    'text':       text,
-                    'language':   info.language,
-                    'confidence': round(confidence, 3),
-                    'timestamp':  time.time(),
-                }
-                self.get_logger().info(
-                    f'[{info.language}] (conf={confidence:.2f}) "{text}"'
-                )
-                msg = String()
-                msg.data = json.dumps(payload, ensure_ascii=False)
-                self.result_pub.publish(msg)
-            else:
+            normalized_text = text.strip()
+            is_low_conf = confidence < self.min_confidence
+            is_empty = not normalized_text
+
+            payload = {
+                'text': normalized_text,
+                'language': info.language,
+                'confidence': round(confidence, 3),
+                'timestamp': time.time(),
+                'event': 'stt_empty_or_low_conf' if (is_empty or is_low_conf) else 'stt_result',
+            }
+
+            if is_empty:
                 self.get_logger().info('Empty transcription result')
+            elif is_low_conf:
+                self.get_logger().info(
+                    f'[{info.language}] low confidence (conf={confidence:.2f} < {self.min_confidence:.2f}) "{normalized_text}"'
+                )
+            else:
+                self.get_logger().info(
+                    f'[{info.language}] (conf={confidence:.2f}) "{normalized_text}"'
+                )
+
+            msg = String()
+            msg.data = json.dumps(payload, ensure_ascii=False)
+            self.result_pub.publish(msg)
 
         except Exception as e:
             self.get_logger().error(f'Transcription failed: {e}')


### PR DESCRIPTION
### Motivation
- Reduce unintended LLM queries from low-confidence STT results and provide a consistent session-level reprompt policy.
- Avoid repeated identical system utterances by adding per-prompt cooldown and centralizing prompt templates.

### Description
- Centralized system messages and STT event names into `SYSTEM_PROMPTS` and `STT_EVENTS` in `ros2_ws/src/interaction_pkg/interaction_pkg/hri_manager_node.py` and added parameters `reprompt_max_count` and `system_prompt_cooldown_sec`.
- Implemented session-scoped reprompt tracking with `reprompt_count` reset on wake and `_handle_reprompt_or_end()` to issue `reprompt_short` or end session when limit reached.
- Added `_say_system()` helper that enforces `system_prompt_cooldown_sec` before emitting a system prompt; applied it for timeout exit, TTS error retry, and target-lost messages.
- In `ros2_ws/src/stt_pkg/stt_pkg/stt_node.py` added `min_confidence` parameter and changed transcription publishing to a structured payload including `text`, `language`, `confidence`, `timestamp`, and `event`, where low-confidence or empty transcriptions set `event: stt_empty_or_low_conf`.

### Testing
- Ran `python -m py_compile ros2_ws/src/interaction_pkg/interaction_pkg/hri_manager_node.py ros2_ws/src/stt_pkg/stt_pkg/stt_node.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12cdc05d64832c90ca1477333c0e2c)