### PR TITLE
Add runtime audio output routing for browser TTS vs ROS audio

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -5,6 +5,7 @@ import FloatingWorkspace  from './components/FloatingWorkspace';
 import SettingsTab        from './tabs/SettingsTab';
 import { useStore, TOPIC_META } from './core/store';
 import { fetchTopicDiagnostics, subscribeROS } from './core/ros';
+import { createAudioOutputRouter } from './core/audioOutput';
 import { PANEL_TREE, findLeaf } from './panelTree';
 
 import './index.css';
@@ -31,6 +32,10 @@ export default function App() {
   const activeMainView   = useStore(s => s.activeMainView);
   const setActiveMainView = useStore(s => s.setActiveMainView);
   const rosBindingEpoch = useStore(s => s.rosBindingEpoch);
+  const audioOutputMode = useStore(s => s.audioOutputMode);
+  const executionProfile = useStore(s => s.executionProfile);
+  const addLog = useStore(s => s.addLog);
+  const setActiveAudioRoute = useStore(s => s.setActiveAudioRoute);
 
   useEffect(() => {
     if (!connected) return;
@@ -71,6 +76,17 @@ export default function App() {
     mq.addEventListener('change', apply);
     return () => mq.removeEventListener('change', apply);
   }, []);
+
+  useEffect(() => {
+    if (!connected) return undefined;
+    const cleanup = createAudioOutputRouter({
+      mode: audioOutputMode,
+      executionProfile,
+      addLog,
+      setActiveAudioRoute,
+    });
+    return cleanup;
+  }, [connected, audioOutputMode, executionProfile, addLog, setActiveAudioRoute]);
 
   function handlePanelSelect(id) {
     const leaf = findLeaf(PANEL_TREE, id);

--- a/web/src/core/audioOutput.js
+++ b/web/src/core/audioOutput.js
@@ -1,0 +1,82 @@
+import { subscribeROS } from './ros';
+import { AUDIO_OUTPUT_MODES, resolveProfileTopics } from './topicProfiles';
+import { LOG_TAGS } from './store';
+
+function parseIncomingAudioPayload(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object') {
+    if (typeof raw.audio_url === 'string') return raw.audio_url;
+    if (typeof raw.url === 'string') return raw.url;
+    if (typeof raw.audio_b64 === 'string') return `data:audio/wav;base64,${raw.audio_b64}`;
+    if (typeof raw.data === 'string') return raw.data;
+  }
+  return null;
+}
+
+function toAbsoluteTopic(topic) {
+  if (!topic) return null;
+  return topic.startsWith('/') ? topic : `/dori/${topic}`;
+}
+
+export function createAudioOutputRouter({ mode, executionProfile, addLog, setActiveAudioRoute }) {
+  const cleanups = [];
+  const profileTopics = resolveProfileTopics(executionProfile);
+
+  addLog(LOG_TAGS.TTS, `[audio-route] activated: ${mode}`);
+  setActiveAudioRoute?.(mode);
+
+  if (mode === AUDIO_OUTPUT_MODES.BROWSER_TTS) {
+    const unsub = subscribeROS('/dori/tts/text', undefined, (payload) => {
+      if (typeof window === 'undefined' || !window.speechSynthesis) return;
+      const text = typeof payload === 'string' ? payload : JSON.stringify(payload);
+      if (!text?.trim()) return;
+      const utterance = new SpeechSynthesisUtterance(text);
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+      addLog(LOG_TAGS.TTS, `[audio-route] browser_tts speak (${text.length} chars)`);
+    });
+    cleanups.push(() => {
+      try { unsub(); } catch { return; }
+      if (typeof window !== 'undefined' && window.speechSynthesis) {
+        window.speechSynthesis.cancel();
+      }
+    });
+  }
+
+  if (mode === AUDIO_OUTPUT_MODES.ROS_AUDIO) {
+    let currentAudio = null;
+    const rosAudioTopic = toAbsoluteTopic(profileTopics.rosAudioStreamTopic) || '/dori/audio/output';
+    const unsub = subscribeROS(rosAudioTopic, undefined, (payload) => {
+      const src = parseIncomingAudioPayload(payload);
+      if (!src || typeof Audio === 'undefined') return;
+      try {
+        if (currentAudio) {
+          currentAudio.pause();
+          currentAudio = null;
+        }
+        currentAudio = new Audio(src);
+        void currentAudio.play().catch(() => {
+          addLog(LOG_TAGS.ERROR, '[audio-route] ros_audio play failed (autoplay blocked or invalid source)');
+        });
+        addLog(LOG_TAGS.TTS, `[audio-route] ros_audio play: ${rosAudioTopic}`);
+      } catch (e) {
+        addLog(LOG_TAGS.ERROR, `[audio-route] ros_audio error: ${e.message}`);
+      }
+    });
+
+    cleanups.push(() => {
+      try { unsub(); } catch { return; }
+      if (currentAudio) {
+        currentAudio.pause();
+        currentAudio = null;
+      }
+    });
+  }
+
+  return () => {
+    cleanups.forEach((fn) => fn());
+    setActiveAudioRoute?.('none');
+    addLog(LOG_TAGS.TTS, `[audio-route] deactivated: ${mode}`);
+  };
+}

--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -340,6 +340,7 @@ export const useStore = create((set, get) => ({
   useClientMic: true,
   useClientCam: true,
   audioOutputMode: AUDIO_OUTPUT_MODES.BROWSER_TTS,
+  activeAudioRoute: AUDIO_OUTPUT_MODES.BROWSER_TTS,
   rosBindingEpoch: 0,
 
   setConnected: (v) => set({ connected: v }),
@@ -357,7 +358,25 @@ export const useStore = create((set, get) => ({
   })),
   setUseClientMic: (v) => set({ useClientMic: !!v }),
   setUseClientCam: (v) => set({ useClientCam: !!v }),
-  setAudioOutputMode: (mode) => set({ audioOutputMode: mode }),
+  setAudioOutputMode: (mode) => set((s) => {
+    const nextMode = Object.values(AUDIO_OUTPUT_MODES).includes(mode)
+      ? mode
+      : AUDIO_OUTPUT_MODES.BROWSER_TTS;
+    const changed = s.audioOutputMode !== nextMode;
+    return {
+      audioOutputMode: nextMode,
+      ...(changed ? {
+        log: [{
+          id: Date.now() + Math.random(),
+          ts: new Date(),
+          tag: LOG_TAGS.TTS,
+          text: `[audio-route] mode changed: ${s.audioOutputMode} -> ${nextMode}`,
+          raw: null,
+        }, ...s.log].slice(0, MAX_LOG),
+      } : {}),
+    };
+  }),
+  setActiveAudioRoute: (route) => set({ activeAudioRoute: route }),
 
 
   // ── Main view (workspace/settings) ─────────────────────────────────────


### PR DESCRIPTION
### Motivation
- `audioOutputMode` was previously only stored in the global store and not used to control actual playback behavior. 
- The app needs a runtime routing layer so selecting `browser_tts` or `ros_audio` in Settings immediately changes how audio is played. 
- Logs and observable state should show which output path is currently active to aid debugging.

### Description
- Added a new audio routing module `web/src/core/audioOutput.js` that exports `createAudioOutputRouter` and implements two runtime routes: `browser_tts` (subscribes to `/dori/tts/text` and uses `SpeechSynthesis`) and `ros_audio` (subscribes to the profile `rosAudioStreamTopic` and plays via `Audio`).
- Wired router lifecycle into `App.jsx` using a `useEffect` that creates/tears down the router when `connected`, `audioOutputMode`, or `executionProfile` change by calling `createAudioOutputRouter`.
- Extended the store (`web/src/core/store.js`) with `activeAudioRoute` and `setActiveAudioRoute`, and enhanced `setAudioOutputMode` to validate incoming mode values and append a `TTS` log entry on mode change.
- Routing lifecycle and playback errors emit debug entries via `addLog` so the active output path and runtime events are visible in the event log.

### Testing
- Ran a production build in the `web/` package with `npm run -s build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f979e328832cbf7e65013caaa9a0)