### PR TITLE
Add browser TTS utility with mobile unlock, duplicate-speech guard, and mode safeguards

### DIFF
--- a/web/src/core/audioOutput.js
+++ b/web/src/core/audioOutput.js
@@ -1,6 +1,7 @@
 import { subscribeROS } from './ros';
 import { AUDIO_OUTPUT_MODES, resolveProfileTopics } from './topicProfiles';
-import { LOG_TAGS } from './store';
+import { LOG_TAGS, useStore } from './store';
+import { createBrowserTtsController } from './browserTts';
 
 function parseIncomingAudioPayload(raw) {
   if (!raw) return null;
@@ -27,20 +28,26 @@ export function createAudioOutputRouter({ mode, executionProfile, addLog, setAct
   setActiveAudioRoute?.(mode);
 
   if (mode === AUDIO_OUTPUT_MODES.BROWSER_TTS) {
-    const unsub = subscribeROS('/dori/tts/text', undefined, (payload) => {
-      if (typeof window === 'undefined' || !window.speechSynthesis) return;
-      const text = typeof payload === 'string' ? payload : JSON.stringify(payload);
-      if (!text?.trim()) return;
-      const utterance = new SpeechSynthesisUtterance(text);
-      window.speechSynthesis.cancel();
-      window.speechSynthesis.speak(utterance);
-      addLog(LOG_TAGS.TTS, `[audio-route] browser_tts speak (${text.length} chars)`);
+    const tts = createBrowserTtsController({
+      addLog,
+      setUnlockWarning: (msg) => useStore.getState().setBrowserTtsWarning(msg),
+      getAudioOutputMode: () => useStore.getState().audioOutputMode,
+      browserTtsMode: AUDIO_OUTPUT_MODES.BROWSER_TTS,
     });
+
+    const removeUnlockHandlers = tts.bindFirstGestureUnlock();
+    const unsub = subscribeROS('/dori/tts/text', undefined, (payload, rawMsg) => {
+      tts.speak({
+        payload,
+        messageId: rawMsg?.id || rawMsg?.header?.stamp,
+        source: '/dori/tts/text',
+      });
+    });
+
     cleanups.push(() => {
       try { unsub(); } catch { return; }
-      if (typeof window !== 'undefined' && window.speechSynthesis) {
-        window.speechSynthesis.cancel();
-      }
+      try { removeUnlockHandlers(); } catch { return; }
+      tts.cancel();
     });
   }
 

--- a/web/src/core/browserTts.js
+++ b/web/src/core/browserTts.js
@@ -1,0 +1,112 @@
+const DEFAULT_LANG = 'ko-KR';
+const DEFAULT_RATE = 1;
+
+function getSpeechSynthesis() {
+  if (typeof window === 'undefined') return null;
+  return window.speechSynthesis || null;
+}
+
+function normalizeText(payload) {
+  if (!payload) return '';
+  if (typeof payload === 'string') return payload;
+  if (typeof payload?.data === 'string') return payload.data;
+  if (typeof payload?.text === 'string') return payload.text;
+  return '';
+}
+
+function buildDedupKey(messageId, text) {
+  if (messageId) return `msg:${messageId}`;
+  return `text:${text.trim()}`;
+}
+
+export function createBrowserTtsController({ addLog, setUnlockWarning, getAudioOutputMode, browserTtsMode }) {
+  let lastSpokenKey = '';
+  let unlocked = false;
+  let unlockAttempted = false;
+
+  const synth = getSpeechSynthesis();
+
+  const ensureGuard = () => getAudioOutputMode?.() === browserTtsMode;
+
+  const cancel = () => {
+    if (!ensureGuard()) return;
+    const s = getSpeechSynthesis();
+    if (s) s.cancel();
+  };
+
+  const unlock = () => {
+    if (unlockAttempted || unlocked) return;
+    unlockAttempted = true;
+
+    const s = getSpeechSynthesis();
+    if (!s || !ensureGuard()) return;
+
+    try {
+      const utterance = new SpeechSynthesisUtterance(' ');
+      utterance.volume = 0;
+      utterance.rate = 1;
+      utterance.onend = () => {
+        unlocked = true;
+        setUnlockWarning?.('');
+      };
+      utterance.onerror = () => {
+        setUnlockWarning?.('브라우저 TTS가 잠겨 있습니다. 화면 터치 후 다시 시도하세요.');
+      };
+      s.speak(utterance);
+    } catch {
+      setUnlockWarning?.('브라우저 정책/권한으로 TTS를 시작할 수 없습니다.');
+    }
+  };
+
+  const onFirstUserGesture = () => {
+    unlock();
+  };
+
+  const speak = ({ payload, messageId, lang = DEFAULT_LANG, rate = DEFAULT_RATE, source = 'unknown' }) => {
+    if (!ensureGuard()) return false;
+
+    const s = getSpeechSynthesis();
+    if (!s || typeof SpeechSynthesisUtterance === 'undefined') return false;
+
+    const text = normalizeText(payload).trim();
+    if (!text) return false;
+
+    const dedupKey = buildDedupKey(messageId, text);
+    if (dedupKey === lastSpokenKey) return false;
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = lang;
+    utterance.rate = Number.isFinite(rate) ? rate : DEFAULT_RATE;
+    utterance.onerror = () => {
+      setUnlockWarning?.('브라우저 TTS 재생이 차단되었습니다. 사용자 상호작용 후 다시 시도하세요.');
+    };
+
+    s.cancel();
+    s.speak(utterance);
+    lastSpokenKey = dedupKey;
+    addLog?.('TTS', `[audio-route] browser_tts speak via ${source} (${text.length} chars)`);
+    return true;
+  };
+
+  const bindFirstGestureUnlock = () => {
+    if (typeof window === 'undefined') return () => {};
+
+    const opts = { once: true, passive: true };
+    window.addEventListener('pointerdown', onFirstUserGesture, opts);
+    window.addEventListener('touchstart', onFirstUserGesture, opts);
+    window.addEventListener('keydown', onFirstUserGesture, { once: true });
+
+    return () => {
+      window.removeEventListener('pointerdown', onFirstUserGesture);
+      window.removeEventListener('touchstart', onFirstUserGesture);
+      window.removeEventListener('keydown', onFirstUserGesture);
+    };
+  };
+
+  return {
+    synth,
+    cancel,
+    speak,
+    bindFirstGestureUnlock,
+  };
+}

--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -341,6 +341,7 @@ export const useStore = create((set, get) => ({
   useClientCam: true,
   audioOutputMode: AUDIO_OUTPUT_MODES.BROWSER_TTS,
   activeAudioRoute: AUDIO_OUTPUT_MODES.BROWSER_TTS,
+  browserTtsWarning: '',
   rosBindingEpoch: 0,
 
   setConnected: (v) => set({ connected: v }),
@@ -365,6 +366,7 @@ export const useStore = create((set, get) => ({
     const changed = s.audioOutputMode !== nextMode;
     return {
       audioOutputMode: nextMode,
+      ...(nextMode !== AUDIO_OUTPUT_MODES.BROWSER_TTS ? { browserTtsWarning: '' } : {}),
       ...(changed ? {
         log: [{
           id: Date.now() + Math.random(),
@@ -377,6 +379,7 @@ export const useStore = create((set, get) => ({
     };
   }),
   setActiveAudioRoute: (route) => set({ activeAudioRoute: route }),
+  setBrowserTtsWarning: (msg) => set({ browserTtsWarning: msg || '' }),
 
 
   // ── Main view (workspace/settings) ─────────────────────────────────────

--- a/web/src/tabs/SettingsTab.jsx
+++ b/web/src/tabs/SettingsTab.jsx
@@ -57,6 +57,7 @@ export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
   const setUseClientCam = useStore(s => s.setUseClientCam);
   const audioOutputMode = useStore(s => s.audioOutputMode);
   const setAudioOutputMode = useStore(s => s.setAudioOutputMode);
+  const browserTtsWarning = useStore(s => s.browserTtsWarning);
 
   const [wsInput, setWsInput] = useState(wsUrl);
   const detectedLang = detectBrowserLang();
@@ -132,6 +133,13 @@ export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
             onChange={setAudioOutputMode}
           />
         </Row>
+
+
+        {audioOutputMode === AUDIO_OUTPUT_MODES.BROWSER_TTS && browserTtsWarning && (
+          <Row label="Browser TTS Notice">
+            <div style={{ color: 'var(--color-error)', fontSize: 12 }}>{browserTtsWarning}</div>
+          </Row>
+        )}
 
         <Row label={t('settings.ws.label')} hint={t('settings.ws.hint')}>
           <div className="sp-ws-row">


### PR DESCRIPTION
### Motivation
- Provide a dedicated browser-side TTS implementation that reliably uses `window.speechSynthesis` while handling mobile/HTTPS user-gesture constraints and avoiding duplicated playback. 
- Ensure browser TTS only runs when the app is configured for `browser_tts` and surface a clear UI warning when playback is blocked by browser policy. 

### Description
- Added `web/src/core/browserTts.js` which exports `createBrowserTtsController` implementing `speak`, `cancel`, first-user-gesture unlock (`bindFirstGestureUnlock`), language/rate handling, and duplicate-utterance prevention using a `messageId`/text dedupe key. 
- Replaced the previous inline browser TTS logic in `web/src/core/audioOutput.js` with the new controller, subscribing to `/dori/tts/text` and passing `rawMsg?.id || rawMsg?.header?.stamp` as the dedupe `messageId`, and ensured strict mode guarding and proper cleanup (remove unlock handlers + `cancel`). 
- Added `browserTtsWarning` state and `setBrowserTtsWarning` setter to `web/src/core/store.js` and clear the warning when switching away from `browser_tts`. 
- Exposed the `browserTtsWarning` in `web/src/tabs/SettingsTab.jsx` so a user-facing notice is shown when `browser_tts` is selected and playback is blocked. 

### Testing
- Ran the repository linter with `cd /workspace/dori/web && npm run -s lint`; the command completed but reported failures due to pre-existing lint errors in unrelated files, so the lint check did not pass overall. 
- No additional automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12faaa9e18832c9500609d14fa0bc0)