### PR TITLE
ROS audio stream playback queue + debug metrics (ros_audio mode)

### DIFF
--- a/web/src/core/audioOutput.js
+++ b/web/src/core/audioOutput.js
@@ -15,6 +15,45 @@ function parseIncomingAudioPayload(raw) {
   return null;
 }
 
+function decodeBase64ToUint8Array(base64Text) {
+  if (!base64Text || typeof atob !== 'function') return null;
+  try {
+    const clean = base64Text.includes(',') ? base64Text.split(',').pop() : base64Text;
+    const binary = atob(clean);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+function coerceAudioBytes(rawMsg) {
+  const src = rawMsg?.data ?? rawMsg;
+  if (!src) return null;
+  if (src instanceof Uint8Array) return src;
+  if (Array.isArray(src)) return Uint8Array.from(src);
+  if (ArrayBuffer.isView(src)) return new Uint8Array(src.buffer, src.byteOffset, src.byteLength);
+  if (src instanceof ArrayBuffer) return new Uint8Array(src);
+  if (typeof src === 'string') return decodeBase64ToUint8Array(src);
+  if (typeof src === 'object') {
+    if (Array.isArray(src.data)) return Uint8Array.from(src.data);
+    if (typeof src.data === 'string') return decodeBase64ToUint8Array(src.data);
+  }
+  return null;
+}
+
+function pcm16ToFloat32(bytes) {
+  const usableLen = bytes.length - (bytes.length % 2);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, usableLen);
+  const out = new Float32Array(usableLen / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    const sample = view.getInt16(i * 2, true);
+    out[i] = Math.max(-1, sample / 32768);
+  }
+  return out;
+}
+
 function toAbsoluteTopic(topic) {
   if (!topic) return null;
   return topic.startsWith('/') ? topic : `/dori/${topic}`;
@@ -52,21 +91,61 @@ export function createAudioOutputRouter({ mode, executionProfile, addLog, setAct
   }
 
   if (mode === AUDIO_OUTPUT_MODES.ROS_AUDIO) {
-    let currentAudio = null;
+    let audioContext = null;
+    let scheduledTime = 0;
+    let packetCount = 0;
+    let underrunCount = 0;
+    const minLeadSec = 0.08;
     const rosAudioTopic = toAbsoluteTopic(profileTopics.rosAudioStreamTopic) || '/dori/audio/output';
-    const unsub = subscribeROS(rosAudioTopic, undefined, (payload) => {
-      const src = parseIncomingAudioPayload(payload);
-      if (!src || typeof Audio === 'undefined') return;
+
+    useStore.getState().resetRosAudioDebug?.();
+
+    const unsub = subscribeROS(rosAudioTopic, 'audio_common_msgs/msg/AudioData', (payload, rawMsg) => {
+      if (useStore.getState().audioOutputMode !== AUDIO_OUTPUT_MODES.ROS_AUDIO) return;
+
+      const bytes = coerceAudioBytes(rawMsg) || coerceAudioBytes(payload);
+      if (!bytes?.length) {
+        const src = parseIncomingAudioPayload(payload);
+        if (!src) return;
+      }
+
       try {
-        if (currentAudio) {
-          currentAudio.pause();
-          currentAudio = null;
+        if (!audioContext) {
+          const Ctx = window.AudioContext || window.webkitAudioContext;
+          if (!Ctx) throw new Error('AudioContext unsupported');
+          audioContext = new Ctx({ sampleRate: 16000 });
         }
-        currentAudio = new Audio(src);
-        void currentAudio.play().catch(() => {
-          addLog(LOG_TAGS.ERROR, '[audio-route] ros_audio play failed (autoplay blocked or invalid source)');
-        });
-        addLog(LOG_TAGS.TTS, `[audio-route] ros_audio play: ${rosAudioTopic}`);
+
+        if (audioContext.state === 'suspended') {
+          void audioContext.resume().catch(() => {
+            addLog(LOG_TAGS.ERROR, '[audio-route] ros_audio resume blocked (need user gesture)');
+          });
+        }
+
+        const float32 = bytes?.length ? pcm16ToFloat32(bytes) : null;
+        if (!float32?.length) return;
+
+        const buffer = audioContext.createBuffer(1, float32.length, 16000);
+        buffer.copyToChannel(float32, 0, 0);
+
+        const now = audioContext.currentTime;
+        if (scheduledTime < now) {
+          underrunCount += 1;
+          scheduledTime = now + minLeadSec;
+        }
+
+        const source = audioContext.createBufferSource();
+        source.buffer = buffer;
+        source.connect(audioContext.destination);
+        source.start(scheduledTime);
+        scheduledTime += buffer.duration;
+
+        packetCount += 1;
+        const queueLength = Math.max(0, Math.ceil((scheduledTime - now) / 0.02));
+        useStore.getState().setRosAudioDebug?.({ packets: packetCount, queueLength, underruns: underrunCount });
+        if (packetCount % 50 === 0) {
+          addLog(LOG_TAGS.TTS, `[audio-route] ros_audio packets=${packetCount} queue=${queueLength} underrun=${underrunCount}`);
+        }
       } catch (e) {
         addLog(LOG_TAGS.ERROR, `[audio-route] ros_audio error: ${e.message}`);
       }
@@ -74,9 +153,11 @@ export function createAudioOutputRouter({ mode, executionProfile, addLog, setAct
 
     cleanups.push(() => {
       try { unsub(); } catch { return; }
-      if (currentAudio) {
-        currentAudio.pause();
-        currentAudio = null;
+      scheduledTime = 0;
+      useStore.getState().resetRosAudioDebug?.();
+      if (audioContext) {
+        void audioContext.close();
+        audioContext = null;
       }
     });
   }

--- a/web/src/core/store.js
+++ b/web/src/core/store.js
@@ -342,6 +342,11 @@ export const useStore = create((set, get) => ({
   audioOutputMode: AUDIO_OUTPUT_MODES.BROWSER_TTS,
   activeAudioRoute: AUDIO_OUTPUT_MODES.BROWSER_TTS,
   browserTtsWarning: '',
+  rosAudioDebug: {
+    packets: 0,
+    queueLength: 0,
+    underruns: 0,
+  },
   rosBindingEpoch: 0,
 
   setConnected: (v) => set({ connected: v }),
@@ -380,6 +385,19 @@ export const useStore = create((set, get) => ({
   }),
   setActiveAudioRoute: (route) => set({ activeAudioRoute: route }),
   setBrowserTtsWarning: (msg) => set({ browserTtsWarning: msg || '' }),
+  setRosAudioDebug: (nextDebug = {}) => set((s) => ({
+    rosAudioDebug: {
+      ...s.rosAudioDebug,
+      ...nextDebug,
+    },
+  })),
+  resetRosAudioDebug: () => set({
+    rosAudioDebug: {
+      packets: 0,
+      queueLength: 0,
+      underruns: 0,
+    },
+  }),
 
 
   // ── Main view (workspace/settings) ─────────────────────────────────────

--- a/web/src/tabs/SettingsTab.jsx
+++ b/web/src/tabs/SettingsTab.jsx
@@ -58,6 +58,7 @@ export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
   const audioOutputMode = useStore(s => s.audioOutputMode);
   const setAudioOutputMode = useStore(s => s.setAudioOutputMode);
   const browserTtsWarning = useStore(s => s.browserTtsWarning);
+  const rosAudioDebug = useStore(s => s.rosAudioDebug);
 
   const [wsInput, setWsInput] = useState(wsUrl);
   const detectedLang = detectBrowserLang();
@@ -138,6 +139,14 @@ export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
         {audioOutputMode === AUDIO_OUTPUT_MODES.BROWSER_TTS && browserTtsWarning && (
           <Row label="Browser TTS Notice">
             <div style={{ color: 'var(--color-error)', fontSize: 12 }}>{browserTtsWarning}</div>
+          </Row>
+        )}
+
+        {audioOutputMode === AUDIO_OUTPUT_MODES.ROS_AUDIO && (
+          <Row label="ROS Audio Debug" hint="수신 패킷/큐 길이/underrun 모니터링">
+            <div style={{ fontSize: 12, fontFamily: 'monospace' }}>
+              packets={rosAudioDebug?.packets ?? 0} | queue={rosAudioDebug?.queueLength ?? 0} | underrun={rosAudioDebug?.underruns ?? 0}
+            </div>
           </Row>
         )}
 


### PR DESCRIPTION
### Motivation
- Provide robust playback for ROS-published audio streams by resolving the runtime topic from the execution profile and turning streaming payloads into browser-playable PCM, while exposing runtime debug counters to help diagnose jitter/underrun issues.

### Description
- Use `resolveProfileTopics(executionProfile).rosAudioStreamTopic` (with `/dori/` namespace) and subscribe via `subscribeROS(..., 'audio_common_msgs/msg/AudioData', ...)`, gated so playback only runs when `audioOutputMode === 'ros_audio'` and early-returns otherwise.
- Add payload coercion helpers to normalize incoming `AudioData` variants (base64 string, Array, `ArrayBuffer`/views, `Uint8Array`) into `Uint8Array` and convert PCM16 LE samples into `Float32` for the Web Audio API.
- Replace one-shot `new Audio(url)` playback with an `AudioContext` + `createBufferSource()` scheduling queue using `scheduledTime` to reduce jitter and count underruns, and close/flush the audio context on cleanup or mode switch.
- Add `rosAudioDebug` to the store with `packets`, `queueLength`, and `underruns` plus `setRosAudioDebug`/`resetRosAudioDebug`, and surface these counters in the Settings UI when `ros_audio` is selected.

### Testing
- Ran `cd web && npm run lint` which failed due to existing unrelated lint errors elsewhere in the repository and not because of the changes introduced here.  
- No new unit/integration tests were added for audio playback; runtime behavior should be validated in a browser connected to a ROS bridge publishing `audio_common_msgs/msg/AudioData` PCM16 LE mono (assumed 16 kHz) stream.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fc02718c832c8a7edfb24b19ba0d)