### PR TITLE
Add configurable TTS playback_mode with publish-only behavior and dashboard audio events

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -196,3 +196,17 @@ IDLE ─────────────────────────
 4. STT Panel에서 mic 녹음 전송 → `stt/audio_input`(런타임 `/dori/stt/audio_input`) 유입 확인.
 5. Vision Panel에서 프레임 publish → `perception/vision/image/compressed`(런타임 `/dori/perception/vision/image/compressed`) 유입 확인.
 6. Speaker Output 모드를 `browser_tts` 또는 `ros_audio` 로 선택해 재생 경로 확인.
+
+
+## Speaker Output × ROS TTS playback_mode 조합
+
+원격 대시보드 테스트에서는 `playback_mode=publish_only` 를 권장한다 (예: `DORI_TTS_PLAYBACK_MODE=publish_only`).
+
+| Speaker Output (Dashboard) | ROS `playback_mode` | 기대 동작 |
+| --- | --- | --- |
+| `browser_tts` | `publish_only` | VM 로컬 재생(`sd.play`, `mpg123`, `ffplay`)은 비활성화되고, `tts/audio_event` 기반으로 대시보드가 재생한다. |
+| `browser_tts` | `local_and_publish` | VM 로컬 재생 + `tts/audio_event` 동시 발행(이중 출력 가능). |
+| `browser_tts` | `local_only` | VM 로컬만 재생되어 원격 브라우저에서는 소리가 나지 않을 수 있다. |
+| `ros_audio` | `publish_only` | VM 로컬 재생 없이 오디오 이벤트만 발행한다(브리지 노드가 있으면 원격/외부 스피커 재생). |
+| `ros_audio` | `local_and_publish` | VM 로컬 재생과 ROS 오디오 경로를 모두 사용한다. |
+| `ros_audio` | `local_only` | VM 로컬 재생만 수행하고 오디오 이벤트는 운용 경로에 활용되지 않는다. |

--- a/docs/dev/parameters.adoc
+++ b/docs/dev/parameters.adoc
@@ -273,10 +273,13 @@ This document is the SSOT for ROS2 parameter details in the current workspace.
 | language | string | `ko` | locale code | - | Speech language.
 | speech_rate | int | 150 | >0 | - | Speech rate (engine-dependent).
 | volume | double | 0.9 | [0,1] | - | Playback volume.
+| playback_mode | string | `local_and_publish` | `local_only/publish_only/local_and_publish` | - | Local playback/publish routing policy.
 | topics.speaking_pub | string | `/tts/speaking` | topic path | - | Speaking-state output.
 | topics.done_pub | string | `/tts/done` | topic path | - | Playback done output.
 | topics.llm_response_sub | string | `/llm/response` | topic path | - | LLM text input.
 | topics.tts_text_sub | string | `/tts/text` | topic path | - | Direct TTS text input.
+| topics.audio_cue_sub | string | `/hri/audio_cue` | topic path | - | Short audio cue input.
+| topics.audio_event_pub | string | `/tts/audio_event` | topic path | - | Audio event publish topic for dashboard/bridge playback.
 |===
 
 *Dynamic reconfigure*:: Not supported

--- a/ros2_ws/src/bringup/launch/voice.launch.py
+++ b/ros2_ws/src/bringup/launch/voice.launch.py
@@ -4,7 +4,7 @@ Voice stack launch (stt/llm/tts only).
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -28,6 +28,10 @@ def generate_launch_description():
         DeclareLaunchArgument('tts_engine', default_value='gtts'),
         DeclareLaunchArgument('tts_language', default_value='ko'),
         DeclareLaunchArgument('sfx_base_path', default_value=''),
+        DeclareLaunchArgument(
+            'tts_playback_mode',
+            default_value=EnvironmentVariable('DORI_TTS_PLAYBACK_MODE', default_value='local_and_publish'),
+        ),
         DeclareLaunchArgument('namespace', default_value='/dori'),
     ]
 
@@ -85,6 +89,7 @@ def generate_launch_description():
             'topics.tts_text_sub': _topic(dori_ns, '/tts/text'),
             'topics.audio_cue_sub': _topic(dori_ns, '/hri/audio_cue'),
             'sfx.base_path': LaunchConfiguration('sfx_base_path'),
+            'playback_mode': LaunchConfiguration('tts_playback_mode'),
         }],
     )
 

--- a/ros2_ws/src/tts_pkg/tts_pkg/tts_node.py
+++ b/ros2_ws/src/tts_pkg/tts_pkg/tts_node.py
@@ -68,6 +68,8 @@ class TTSNode(Node):
         self.declare_parameter('topics.tts_text_sub', 'tts/text')
         self.declare_parameter('topics.audio_cue_sub', 'hri/audio_cue')
         self.declare_parameter('sfx.base_path', '')
+        self.declare_parameter('playback_mode', 'local_and_publish')
+        self.declare_parameter('topics.audio_event_pub', 'tts/audio_event')
 
         self.engine_name = self.get_parameter('tts_engine').value
         self.language = self.get_parameter('language').value
@@ -82,6 +84,13 @@ class TTSNode(Node):
         self.sfx_base_path = self._resolve_sfx_base_path(
             self.get_parameter('sfx.base_path').value
         )
+        self.playback_mode = self.get_parameter('playback_mode').value
+        valid_playback_modes = {'local_only', 'publish_only', 'local_and_publish'}
+        if self.playback_mode not in valid_playback_modes:
+            self.get_logger().warn(
+                f'Invalid playback_mode: {self.playback_mode} — fallback to local_and_publish'
+            )
+            self.playback_mode = 'local_and_publish'
 
         speaking_topic = self.get_parameter('topics.speaking_pub').value
         done_topic = self.get_parameter('topics.done_pub').value
@@ -89,11 +98,13 @@ class TTSNode(Node):
         llm_response_topic = self.get_parameter('topics.llm_response_sub').value
         tts_text_topic = self.get_parameter('topics.tts_text_sub').value
         audio_cue_topic = self.get_parameter('topics.audio_cue_sub').value
+        audio_event_topic = self.get_parameter('topics.audio_event_pub').value
 
         # Publishers
         self.speaking_pub = self.create_publisher(Bool, speaking_topic, 10)
         self.done_pub = self.create_publisher(Bool, done_topic, 10)
         self.done_detail_pub = self.create_publisher(String, done_detail_topic, 10)
+        self.audio_event_pub = self.create_publisher(String, audio_event_topic, 10)
 
         # Subscribers
         self.create_subscription(String, llm_response_topic, self._on_text, 10)
@@ -111,6 +122,7 @@ class TTSNode(Node):
 
         self.get_logger().info(f'TTS Node started (engine: {self.engine_name})')
         self.get_logger().info(f'SFX base path: {self.sfx_base_path}')
+        self.get_logger().info(f'Playback mode: {self.playback_mode}')
 
     def _init_engine(self):
         if self.engine_name == 'pyttsx3':
@@ -182,6 +194,8 @@ class TTSNode(Node):
                 self._pub_speaking(True)
                 self.get_logger().info(f'Speaking: "{text[:60]}"')
 
+                self._publish_audio_event('tts_text', {'text': text, 'engine': self.engine_name})
+
                 if self.engine_name == 'pyttsx3':
                     self._speak_pyttsx3(text)
                 elif self.engine_name == 'gtts':
@@ -199,6 +213,9 @@ class TTSNode(Node):
                 self.get_logger().info('Speech complete')
 
     def _speak_pyttsx3(self, text: str):
+        if self.playback_mode == 'publish_only':
+            self.get_logger().info('publish_only mode: skip pyttsx3 local playback')
+            return
         self._pyttsx3.say(text)
         self._pyttsx3.runAndWait()
 
@@ -207,6 +224,10 @@ class TTSNode(Node):
             tmp = fp.name
         try:
             gTTS(text=text, lang=self.language, slow=False).save(tmp)
+            if self.playback_mode == 'publish_only':
+                self.get_logger().info('publish_only mode: skip gTTS local playback')
+                return
+
             if AUDIO_AVAILABLE:
                 data, sr = sf.read(tmp)
                 sd.play(data, sr)
@@ -245,6 +266,8 @@ class TTSNode(Node):
             self.get_logger().warn(f'Unknown audio cue: "{cue_name}"')
             return
 
+        self._publish_audio_event('audio_cue', {'cue_name': cue_name})
+
         cue_path = self._cue_file_path(cue_name)
         if not self.sfx_base_path or not cue_path.exists():
             self.get_logger().warn(
@@ -253,6 +276,10 @@ class TTSNode(Node):
             return
 
         try:
+            if self.playback_mode == 'publish_only':
+                self.get_logger().info('publish_only mode: skip local audio cue playback')
+                return
+
             if AUDIO_AVAILABLE:
                 data, sr = sf.read(str(cue_path))
                 sd.play(data, sr)
@@ -266,6 +293,20 @@ class TTSNode(Node):
             self.get_logger().warn(
                 f'Audio cue playback failed ({cue_name}): {e} — fallback to silence'
             )
+
+
+    def _publish_audio_event(self, event_type: str, payload: dict):
+        if self.playback_mode == 'local_only':
+            return
+
+        msg = String()
+        msg.data = json.dumps({
+            'event_type': event_type,
+            'playback_mode': self.playback_mode,
+            'timestamp': time.time(),
+            **payload,
+        }, ensure_ascii=False)
+        self.audio_event_pub.publish(msg)
 
     def _pub_speaking(self, value: bool):
         msg = Bool()


### PR DESCRIPTION
### Motivation
- Provide an operator-controllable policy to route TTS playback either to the local VM, to a remote dashboard/bridge, or both to avoid duplicate/undesired local playback during remote testing.
- Allow environment-based defaults so CI/remote-test environments can set `publish_only` without code changes.
- Make operator expectations explicit by documenting how Dashboard `Speaker Output` modes interact with ROS TTS routing.

### Description
- Added a `playback_mode` ROS parameter to `tts_node` with supported values `local_only`, `publish_only`, and `local_and_publish`, and validate/fallback to `local_and_publish` on invalid values (`ros2_ws/src/tts_pkg/tts_pkg/tts_node.py`).
- Implemented `publish_only` semantics that skip VM-local playback paths (skip `pyttsx3` local speak, skip `sd.play` and shell fallbacks `mpg123`/`ffplay` for gTTS, and skip local SFX cue playback) while preserving lifecycle topics like `tts/speaking` and `tts/done`.
- Added a structured audio event publisher `topics.audio_event_pub` (default `tts/audio_event`) and publish audio events for both TTS text and audio cues so dashboard/bridge components can perform playback when local playback is disabled.
- Updated `bringup/launch/voice.launch.py` to accept a `tts_playback_mode` launch argument that defaults from the environment variable `DORI_TTS_PLAYBACK_MODE` (fallback `local_and_publish`) and pass it into the TTS node parameters.
- Updated documentation in `docs/dev/parameters.adoc` and `docs/dev/architecture.md` to include the new `playback_mode` parameter, `topics.audio_event_pub`, and an operator-facing matrix describing expected behavior for `Speaker Output` × ROS `playback_mode` combinations.

### Testing
- Ran `python -m py_compile ros2_ws/src/tts_pkg/tts_pkg/tts_node.py ros2_ws/src/bringup/launch/voice.launch.py` to validate Python syntax and the check completed successfully.
- No unit tests were added in this change; manual/runtime verification is expected when deploying with different `DORI_TTS_PLAYBACK_MODE` values (recommended `publish_only` for remote dashboard tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fe550b68832ca455c6777e1368e5)