### PR TITLE
Expand speaker output guidance and localize audio-output messaging

### DIFF
--- a/web/src/core/i18n.js
+++ b/web/src/core/i18n.js
@@ -142,6 +142,15 @@ const TRANSLATIONS = {
     'settings.section.connection': 'Connection',
     'settings.ws.label': 'ROS WebSocket URL',
     'settings.ws.hint': 'Default: ws://[Robot IP]:9090',
+    'settings.audioOutput.label': 'Speaker Output',
+    'settings.audioOutput.hint': 'Choose where TTS audio is played. Mobile browsers may require HTTPS and a user gesture.',
+    'settings.audioOutput.mode.browserTts': 'browser_tts',
+    'settings.audioOutput.mode.rosAudio': 'ros_audio',
+    'settings.audioOutput.modeHint.browserTts': 'Plays through the connected device browser speaker.',
+    'settings.audioOutput.modeHint.rosAudio': 'Plays ROS audio topic stream in this browser.',
+    'settings.audioOutput.modeHelp.browserTts': 'Output goes to the current device browser speaker.',
+    'settings.audioOutput.conflict.badge': 'Conflict Risk',
+    'settings.audioOutput.conflict.text': 'Server local TTS is active by backend policy and may overlap with browser_tts playback.',
 
     // HRI / Perception panel texts
     'panel.tts.placeholder': 'Text for robot speech (e.g. Hello, I am DORI.)',
@@ -247,6 +256,15 @@ const TRANSLATIONS = {
     'settings.section.connection': '연결',
     'settings.ws.label': 'ROS WebSocket URL',
     'settings.ws.hint': '기본값: ws://[로봇 IP]:9090',
+    'settings.audioOutput.label': '스피커 출력',
+    'settings.audioOutput.hint': 'TTS 오디오 재생 위치를 선택하세요. 모바일 브라우저는 HTTPS와 사용자 제스처가 필요할 수 있습니다.',
+    'settings.audioOutput.mode.browserTts': 'browser_tts',
+    'settings.audioOutput.mode.rosAudio': 'ros_audio',
+    'settings.audioOutput.modeHint.browserTts': '접속한 기기 브라우저 스피커로 재생합니다.',
+    'settings.audioOutput.modeHint.rosAudio': 'ROS 오디오 토픽을 브라우저에서 재생합니다.',
+    'settings.audioOutput.modeHelp.browserTts': '현재 접속한 기기의 브라우저 스피커로 출력됩니다.',
+    'settings.audioOutput.conflict.badge': '충돌 가능',
+    'settings.audioOutput.conflict.text': '백엔드 정책으로 서버 로컬 TTS가 활성화되어 browser_tts 재생과 겹칠 수 있습니다.',
 
     // HRI / Perception panel texts
     'panel.tts.placeholder': '로봇이 말할 텍스트 (예: 안녕하세요, 도리입니다.)',

--- a/web/src/tabs/SettingsTab.jsx
+++ b/web/src/tabs/SettingsTab.jsx
@@ -124,11 +124,14 @@ export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
         <Row label="Client Camera">
           <input type="checkbox" checked={useClientCam} onChange={e => setUseClientCam(e.target.checked)} />
         </Row>
-        <Row label="Speaker Output" hint="모바일 브라우저는 HTTPS/사용자 제스처가 필요할 수 있습니다.">
+        <Row
+          label={t('settings.audioOutput.label')}
+          hint={t('settings.audioOutput.hint')}
+        >
           <Seg
             options={[
-              { value: AUDIO_OUTPUT_MODES.BROWSER_TTS, label: 'browser_tts' },
-              { value: AUDIO_OUTPUT_MODES.ROS_AUDIO, label: 'ros_audio' },
+              { value: AUDIO_OUTPUT_MODES.BROWSER_TTS, label: t('settings.audioOutput.mode.browserTts') },
+              { value: AUDIO_OUTPUT_MODES.ROS_AUDIO, label: t('settings.audioOutput.mode.rosAudio') },
             ]}
             value={audioOutputMode}
             onChange={setAudioOutputMode}
@@ -136,14 +139,41 @@ export default function SettingsTab({ themeMode, onThemeModeChange, onClose }) {
         </Row>
 
 
-        {audioOutputMode === AUDIO_OUTPUT_MODES.BROWSER_TTS && browserTtsWarning && (
-          <Row label="Browser TTS Notice">
-            <div style={{ color: 'var(--color-error)', fontSize: 12 }}>{browserTtsWarning}</div>
+        {audioOutputMode === AUDIO_OUTPUT_MODES.BROWSER_TTS && (
+          <Row
+            label={t('settings.audioOutput.mode.browserTts')}
+            hint={t('settings.audioOutput.modeHint.browserTts')}
+          >
+            {browserTtsWarning ? (
+              <div style={{ color: 'var(--color-error)', fontSize: 12, display: 'flex', gap: 8, alignItems: 'center' }}>
+                <span
+                  style={{
+                    padding: '2px 6px',
+                    borderRadius: 999,
+                    background: 'color-mix(in srgb, var(--color-error) 15%, transparent)',
+                    border: '1px solid color-mix(in srgb, var(--color-error) 35%, transparent)',
+                    fontWeight: 700,
+                    letterSpacing: 0.2,
+                  }}
+                >
+                  {t('settings.audioOutput.conflict.badge')}
+                </span>
+                <span>{t('settings.audioOutput.conflict.text')}</span>
+              </div>
+            ) : (
+              <div style={{ fontSize: 12 }}>{t('settings.audioOutput.modeHelp.browserTts')}</div>
+            )}
+            {browserTtsWarning && (
+              <div style={{ color: 'var(--color-error)', fontSize: 12, marginTop: 4 }}>{browserTtsWarning}</div>
+            )}
           </Row>
         )}
 
         {audioOutputMode === AUDIO_OUTPUT_MODES.ROS_AUDIO && (
-          <Row label="ROS Audio Debug" hint="수신 패킷/큐 길이/underrun 모니터링">
+          <Row
+            label={t('settings.audioOutput.mode.rosAudio')}
+            hint={t('settings.audioOutput.modeHint.rosAudio')}
+          >
             <div style={{ fontSize: 12, fontFamily: 'monospace' }}>
               packets={rosAudioDebug?.packets ?? 0} | queue={rosAudioDebug?.queueLength ?? 0} | underrun={rosAudioDebug?.underruns ?? 0}
             </div>


### PR DESCRIPTION
### Motivation
- Improve clarity of the Settings UI for audio playback so users understand where TTS audio will be played and mobile-browser constraints. 
- Make the distinction between `browser_tts` and `ros_audio` explicit to reduce confusion when selecting output modes. 
- Surface a visible conflict indicator when server-local TTS may overlap with browser playback and keep localization consistent across languages. 

### Description
- Replaced the hard-coded `Speaker Output` label/hint in `web/src/tabs/SettingsTab.jsx` with i18n keys and expanded the hint text via `t('settings.audioOutput.*')` usage. 
- Switched the audio-mode option labels to use `t('settings.audioOutput.mode.browserTts')` and `t('settings.audioOutput.mode.rosAudio')` so copy is localized. 
- Added a `browser_tts` details block that shows a localized helper line or, when present, a conflict badge plus localized conflict text and the existing `browserTtsWarning` message; styling for the badge is included inline. 
- Reworked the `ros_audio` UI block to show a localized label and hint clarifying that it plays a ROS audio topic stream in the browser. 
- Added matching English and Korean translation keys in `web/src/core/i18n.js` under `settings.audioOutput.*` to keep `en`/`ko` consistent. 

### Testing
- No automated unit/integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130130ab94832c83436ed02e1e204c)