### PR TITLE
Skip perception_camera_cpp C++ camera build when librealsense is missing

### DIFF
--- a/ros2_ws/src/perception_camera_cpp/CMakeLists.txt
+++ b/ros2_ws/src/perception_camera_cpp/CMakeLists.txt
@@ -11,24 +11,28 @@ find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(realsense2 REQUIRED)
+find_package(realsense2 QUIET)
 
-add_executable(depth_camera_node src/depth_camera_node.cpp)
-ament_target_dependencies(depth_camera_node
-  rclcpp
-  sensor_msgs
-  std_msgs
-  cv_bridge
-)
-target_link_libraries(depth_camera_node
-  ${OpenCV_LIBRARIES}
-  realsense2::realsense2
-)
+if(NOT realsense2_FOUND)
+  message(WARNING "realsense2 was not found. Skipping depth_camera_node build for perception_camera_cpp.")
+else()
+  add_executable(depth_camera_node src/depth_camera_node.cpp)
+  ament_target_dependencies(depth_camera_node
+    rclcpp
+    sensor_msgs
+    std_msgs
+    cv_bridge
+  )
+  target_link_libraries(depth_camera_node
+    ${OpenCV_LIBRARIES}
+    realsense2::realsense2
+  )
 
-target_compile_features(depth_camera_node PUBLIC cxx_std_17)
+  target_compile_features(depth_camera_node PUBLIC cxx_std_17)
 
-install(TARGETS depth_camera_node
-  DESTINATION lib/${PROJECT_NAME}
-)
+  install(TARGETS depth_camera_node
+    DESTINATION lib/${PROJECT_NAME}
+  )
+endif()
 
 ament_package()


### PR DESCRIPTION
### Motivation
- Allow the workspace to build on systems that do not have the Intel RealSense SDK (`realsense2`) installed and rely on the Python camera path instead.

### Description
- Change `find_package(realsense2 REQUIRED)` to `find_package(realsense2 QUIET)` in `ros2_ws/src/perception_camera_cpp/CMakeLists.txt` and add an `if(NOT realsense2_FOUND)` branch that emits a warning and skips the C++ node build.
- When `realsense2` is found, the previous behavior is preserved: `depth_camera_node` is added, linked against `realsense2::realsense2` and installed.

### Testing
- Attempted `cd ros2_ws && colcon build --packages-select perception_camera_cpp`, but the environment does not have `colcon` installed so the build could not be executed here (test failed due to missing `colcon`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d8a07944832ca6c5794ba1bcf66d)